### PR TITLE
Using Airtable Form instead of Google Form when new members join

### DIFF
--- a/src/posts/join.md
+++ b/src/posts/join.md
@@ -10,4 +10,4 @@ You are now one of them.
 Get involved with the PauseAI movement by signing up below.
 You will receive periodic updates on the movement and how you can help.
 
-[Join here](https://docs.google.com/forms/d/e/1FAIpQLSc5P8xYB6l_KraUOyHSI--wGJnvMMMp4zAG6EjNGJIeG5MIFA/viewform?usp=sf_link)
+[Join here](https://airtable.com/appWPTGqZmUcs3NWu/shr1rI3Fo3JTckfuK)


### PR DESCRIPTION
**This PR changes the link when newcomers click the Join button from a Google Form to an Airtable Form**. This form is linked to the following table: https://airtable.com/appWPTGqZmUcs3NWu/shr88C3XmqJgAhqKk that is a replica of the Google Spreadsheet (with all the current data filled in). The form can be accessed here: https://airtable.com/appWPTGqZmUcs3NWu/shr1rI3Fo3JTckfuK

I believe moving to Airtable is a good idea for:
- Consistency with the other forms that we use internally
- **Having all our data stored in the same place**
- Airtable saves data in a nicer format than google sheet
- **Airtable API is nice**
- This will allow **powerful automations** and integrations, for example Project Bot will be able to send a notification to the onboarding discord channel when somebody signs the form