### PR TITLE
Teams using airtable

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
 		"remark-unwrap-images": "^3.0.1",
 		"shiki": "^0.14.7",
 		"svelte-french-toast": "^1.2.0",
+		"svelte-markdown": "^0.4.1",
 		"svelte-toc": "^0.5.8"
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,6 +62,9 @@ dependencies:
   svelte-french-toast:
     specifier: ^1.2.0
     version: 1.2.0(svelte@4.2.12)
+  svelte-markdown:
+    specifier: ^0.4.1
+    version: 0.4.1(svelte@4.2.12)
   svelte-toc:
     specifier: ^0.5.8
     version: 0.5.8
@@ -938,6 +941,10 @@ packages:
     resolution: {integrity: sha512-Dx9MuF2kKgT/N22LsMUB4b3acFZh9clVqz9zv1fomoiPoBrJolwYxpWA/9LPO/2N0xWbKi4V+pkjTaFkkx/4wA==}
     dependencies:
       '@types/geojson': 7946.0.14
+    dev: false
+
+  /@types/marked@5.0.2:
+    resolution: {integrity: sha512-OucS4KMHhFzhz27KxmWg7J+kIYqyqoW5kdIEI319hqARQQUTqhao3M/F+uFnDXD0Rg72iDDZxZNxq5gvctmLlg==}
     dev: false
 
   /@types/mdast@3.0.15:
@@ -1974,6 +1981,12 @@ packages:
       vt-pbf: 3.1.3
     dev: false
 
+  /marked@5.1.2:
+    resolution: {integrity: sha512-ahRPGXJpjMjwSOlBoTMZAK7ATXkli5qCPxZ21TG44rx1KEo44bii4ekgTDQPNRQ4Kh7JMb9Ub1PVk1NxRSsorg==}
+    engines: {node: '>= 16'}
+    hasBin: true
+    dev: false
+
   /mdast-util-to-string@4.0.0:
     resolution: {integrity: sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==}
     dependencies:
@@ -2537,6 +2550,16 @@ packages:
       svelte: ^3.19.0 || ^4.0.0
     dependencies:
       svelte: 4.2.12
+
+  /svelte-markdown@0.4.1(svelte@4.2.12):
+    resolution: {integrity: sha512-pOlLY6EruKJaWI9my/2bKX8PdTeP5CM0s4VMmwmC2prlOkjAf+AOmTM4wW/l19Y6WZ87YmP8+ZCJCCwBChWjYw==}
+    peerDependencies:
+      svelte: ^4.0.0
+    dependencies:
+      '@types/marked': 5.0.2
+      marked: 5.1.2
+      svelte: 4.2.12
+    dev: false
 
   /svelte-preprocess@5.1.3(postcss@8.4.38)(svelte@4.2.12)(typescript@5.4.3):
     resolution: {integrity: sha512-xxAkmxGHT+J/GourS5mVJeOXZzne1FR5ljeOUAMXUkfEhkLEllRreXpbl3dIYJlcJRfL1LO1uIAPpBpBfiqGPw==}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,0 +1,10 @@
+import { AIRTABLE_API_KEY } from '$env/static/private'
+
+/** Fetch options for getting data from Airtable */
+export const options = {
+	method: 'GET',
+	headers: {
+		Authorization: `Bearer ${AIRTABLE_API_KEY}`,
+		'Content-Type': 'application/json'
+	}
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -22,3 +22,10 @@ export type Person = {
 	bio: string
 	title?: string
 }
+
+export type Team = {
+	id: string
+	name: string
+	description: string
+	lead: string
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -27,5 +27,6 @@ export type Team = {
 	id: string
 	name: string
 	description: string
-	lead: string
+	leadName: string
+	leadEmail: string
 }

--- a/src/routes/api/people/+server.ts
+++ b/src/routes/api/people/+server.ts
@@ -1,4 +1,5 @@
 import { AIRTABLE_API_KEY } from '$env/static/private'
+import { options } from '$lib/api.js'
 import type { Person } from '$lib/types.js'
 import { json } from '@sveltejs/kit'
 
@@ -14,13 +15,6 @@ function recordToPerson(record: any): Person {
 
 export async function GET({ fetch }) {
 	const url = `https://api.airtable.com/v0/appWPTGqZmUcs3NWu/tblZhQc49PkCz3yHd`
-	const options = {
-		method: 'GET',
-		headers: {
-			Authorization: `Bearer ${AIRTABLE_API_KEY}`,
-			'Content-Type': 'application/json'
-		}
-	}
 
 	const response = await fetch(url, options)
 	if (!response.ok) {

--- a/src/routes/api/teams/+server.ts
+++ b/src/routes/api/teams/+server.ts
@@ -3,12 +3,12 @@ import { json } from '@sveltejs/kit'
 import { options } from '$lib/api.js'
 
 function recordToTeam(record: any): Team {
-	console.log(record.fields)
 	return {
 		id: record.id || 'noId',
-		name: record.fields.Name,
-		description: record.fields.Mission,
-		lead: record.fields['Name (from Lead)']
+		name: record.fields.name,
+		description: record.fields.mission,
+		leadName: record.fields.name_from_lead,
+		leadEmail: record.fields.email_address_from_lead
 	}
 }
 

--- a/src/routes/api/teams/+server.ts
+++ b/src/routes/api/teams/+server.ts
@@ -1,0 +1,25 @@
+import type { Team } from '$lib/types.js'
+import { json } from '@sveltejs/kit'
+import { options } from '$lib/api.js'
+
+function recordToTeam(record: any): Team {
+	console.log(record.fields)
+	return {
+		id: record.id || 'noId',
+		name: record.fields.Name,
+		description: record.fields.Mission,
+		lead: record.fields['Name (from Lead)']
+	}
+}
+
+export async function GET({ fetch }) {
+	const url = `https://api.airtable.com/v0/appWPTGqZmUcs3NWu/tblYLOPzJ32QOdBLg`
+
+	const response = await fetch(url, options)
+	if (!response.ok) {
+		throw new Error('Failed to fetch data from Airtable')
+	}
+	const data = await response.json()
+	const out: Team[] = data.records.map(recordToTeam)
+	return json(out)
+}

--- a/src/routes/teams/+page.svelte
+++ b/src/routes/teams/+page.svelte
@@ -5,19 +5,29 @@
 	export let data
 	const { props } = data
 	const { title, description, date } = meta
+	import SvelteMarkdown from 'svelte-markdown'
 </script>
 
 <PostMeta {title} {description} {date} />
 
 <h1>{title}</h1>
 
+<SvelteMarkdown
+	source={`
+PauseAI consists almost exclusively of [volunteers](/people) ([sign up
+here](https://airtable.com/appWPTGqZmUcs3NWu/pag7ztLh27Omj5s2n/form)). We are organized in teams,
+each working on a different aspect of our movement. Every team has a leader, regular meetings, and
+a Role on the [discord server](https://discord.gg/2XXWXvErfA).
+`}
+/>
+
 <section data-pagefind-ignore>
 	{#if props.length === 0}
 		<p>No team members found</p>
 	{/if}
 	<ul class="people">
-		{#each props as { name, description, lead }}
-			<Team {name} {description} {lead} />
+		{#each props as { name, description, leadName, leadEmail }}
+			<Team {name} {description} {leadName} {leadEmail} />
 		{/each}
 	</ul>
 </section>

--- a/src/routes/teams/+page.svelte
+++ b/src/routes/teams/+page.svelte
@@ -1,0 +1,30 @@
+<script lang="ts">
+	import PostMeta from '$lib/components/PostMeta.svelte'
+	import { meta } from './meta'
+	import Team from './team.svelte'
+	export let data
+	const { props } = data
+	const { title, description, date } = meta
+</script>
+
+<PostMeta {title} {description} {date} />
+
+<h1>{title}</h1>
+
+<section data-pagefind-ignore>
+	{#if props.length === 0}
+		<p>No team members found</p>
+	{/if}
+	<ul class="people">
+		{#each props as { name, description, lead }}
+			<Team {name} {description} {lead} />
+		{/each}
+	</ul>
+</section>
+
+<style>
+	.people {
+		display: grid;
+		gap: 1rem;
+	}
+</style>

--- a/src/routes/teams/+page.ts
+++ b/src/routes/teams/+page.ts
@@ -1,0 +1,11 @@
+import type { Team } from '$lib/types'
+
+export const prerender = false
+
+export const load = async ({ fetch }) => {
+	const response = await fetch('api/teams')
+	const posts: Team[] = await response.json()
+	return {
+		props: posts
+	}
+}

--- a/src/routes/teams/meta.ts
+++ b/src/routes/teams/meta.ts
@@ -1,0 +1,9 @@
+import type { Post } from '$lib/types'
+
+export const meta: Post = {
+	title: 'Teams of PauseAI',
+	description: 'What are the various teams at PauseAI?',
+	date: '2024-04-23',
+	slug: 'teams',
+	categories: []
+}

--- a/src/routes/teams/team.svelte
+++ b/src/routes/teams/team.svelte
@@ -1,0 +1,87 @@
+<script lang="ts">
+	export let description: string | undefined
+	export let name: string | undefined
+	export let lead: string | undefined
+
+	const len = 60
+	let bioOpen = false
+	let bioTruncated = description?.substring(0, len)
+</script>
+
+<li class="person">
+	<div class="details">
+		<div class="name-title">
+			<div class="name">
+				{name}
+			</div>
+		</div>
+		{#if description}
+			<div class="bio">
+				{bioOpen ? description : bioTruncated}
+				{#if !bioOpen && description.length > len}
+					<button on:click={() => (bioOpen = !bioOpen)}>...</button>
+				{/if}
+			</div>
+		{/if}
+		<div class="lead">{lead}</div>
+	</div>
+</li>
+
+<style>
+	.person {
+		display: flex;
+		gap: 1rem;
+	}
+
+	.details {
+		flex-shrink: 1;
+	}
+
+	.name-title {
+		display: flex;
+		flex-direction: row;
+		align-items: center;
+		gap: 0.5rem;
+	}
+
+	.bio {
+		position: relative;
+		/* /* show all formatting, like newlines */
+		white-space: pre-wrap;
+		overflow-wrap: break-word;
+		word-wrap: break-word;
+		font-size: 0.9rem;
+	}
+
+	.bio button {
+		background: none;
+		border: none;
+		color: var(--brand);
+		cursor: pointer;
+		text-decoration: underline;
+		font-size: 0.9rem;
+		margin-left: -0.5rem;
+	}
+
+	.bio button:hover {
+		color: var(--brand-dark);
+		background-color: var(--bg-subtle);
+		border-radius: 6px;
+	}
+
+	.name {
+		color: var(--text);
+		font-family: var(--font-heading);
+		font-weight: bold;
+		text-decoration: none;
+		font-size: 1.4rem;
+		text-transform: capitalize;
+		margin: 0;
+	}
+
+	.title {
+		font-weight: normal;
+		font-family: var(--font-body);
+		font-size: 1rem;
+	}
+</style>

--- a/src/routes/teams/team.svelte
+++ b/src/routes/teams/team.svelte
@@ -1,72 +1,36 @@
 <script lang="ts">
+	import SvelteMarkdown from 'svelte-markdown'
+
 	export let description: string | undefined
 	export let name: string | undefined
-	export let lead: string | undefined
-
-	const len = 60
-	let bioOpen = false
-	let bioTruncated = description?.substring(0, len)
+	export let leadName: string | undefined
+	export let leadEmail: string | undefined
 </script>
 
-<li class="person">
-	<div class="details">
-		<div class="name-title">
-			<div class="name">
-				{name}
-			</div>
-		</div>
-		{#if description}
-			<div class="bio">
-				{bioOpen ? description : bioTruncated}
-				{#if !bioOpen && description.length > len}
-					<button on:click={() => (bioOpen = !bioOpen)}>...</button>
-				{/if}
-			</div>
-		{/if}
-		<div class="lead">{lead}</div>
+<li class="team">
+	<div class="name">
+		{name}
 	</div>
+	<div class="description prose">
+		<SvelteMarkdown source={description} />
+	</div>
+	<div class="lead">Team leader: <a href={`mailto:${leadEmail}`} class="lead">{leadName}</a></div>
 </li>
 
 <style>
-	.person {
+	.team {
 		display: flex;
-		gap: 1rem;
-	}
-
-	.details {
-		flex-shrink: 1;
-	}
-
-	.name-title {
-		display: flex;
-		flex-direction: row;
-		align-items: center;
+		flex-direction: column;
+		position: relative;
 		gap: 0.5rem;
 	}
 
-	.bio {
+	.description {
 		position: relative;
 		/* /* show all formatting, like newlines */
 		white-space: pre-wrap;
 		overflow-wrap: break-word;
 		word-wrap: break-word;
-		font-size: 0.9rem;
-	}
-
-	.bio button {
-		background: none;
-		border: none;
-		color: var(--brand);
-		cursor: pointer;
-		text-decoration: underline;
-		font-size: 0.9rem;
-		margin-left: -0.5rem;
-	}
-
-	.bio button:hover {
-		color: var(--brand-dark);
-		background-color: var(--bg-subtle);
-		border-radius: 6px;
 	}
 
 	.name {
@@ -77,11 +41,5 @@
 		font-size: 1.4rem;
 		text-transform: capitalize;
 		margin: 0;
-	}
-
-	.title {
-		font-weight: normal;
-		font-family: var(--font-body);
-		font-size: 1rem;
 	}
 </style>


### PR DESCRIPTION
As of now, the /teams page is a simple markdown file. @Maximophone has added a table in Airtable for `teams`. This could have some benefits:

- Manage the content from airtable, keep one source of truth for teams / leads / volunteers
- Do some extra fancy views for teams (as we did with [people](https://pauseai.info/people))

## Questions

- Can we show a list of volunteers per team? Perhaps even with profile picture? Would be awesome.
- Can we make this work with the search feature? 
- Is this enough of an improvement?

## Todo

- [x] Link to airtable
- [x] Don't replicate too much client code
- [x] Make it pretty
- [x] Render markdown (especially links)