### PR TITLE
Fix markdown imports

### DIFF
--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -17,5 +17,3 @@ declare module '*.md' {
 	}
 	export const metadata: Record<string, any>
 }
-
-export {}


### PR DESCRIPTION
Remove `export {}` from `app.d.ts` to keep type declarations in the global scope. This allows `.md` file type declarations to be recognized project-wide, fixing module resolution errors for Markdown imports.

Otherwise, doing:
`import MyPost from '../../posts/mypost.md'` throws `Cannot find module '../../posts/mypost.md' or its corresponding type declarations.ts (2307)`