### PR TITLE
Exclude prerendered routes from edge function

### DIFF
--- a/src/lib/adapter-netlify-selective.js
+++ b/src/lib/adapter-netlify-selective.js
@@ -1,0 +1,31 @@
+import adapter from '@sveltejs/adapter-netlify'
+import fs from 'fs/promises'
+
+const NAME = 'adapter-netlify-selective'
+const MANIFEST_PATH = '.netlify/edge-functions/manifest.json'
+const FUNCTION_NAME = 'render'
+
+export default function ({ split = undefined, edge = undefined } = {}) {
+	const adapterNetlify = adapter({ split, edge })
+	adapterNetlify.name = NAME
+	const adaptNetlify = adapterNetlify.adapt
+	adapterNetlify.adapt = async function (builder) {
+		await adaptNetlify(builder)
+
+		if (!edge) throw new Error(`${NAME} only works for edge functions`)
+
+		const dynamicRoutes = builder.routes.filter((route) => !route.prerender)
+		const dynamicRoutesPattern = dynamicRoutes
+			.map((route) => '(' + route.pattern.source + ')')
+			.join('|')
+
+		/** @type import("./types").EdgeManifest */
+		const edgeManifest = JSON.parse(await fs.readFile(MANIFEST_PATH, 'utf-8'))
+		const renderFunction = edgeManifest.functions.find((f) => f.function == FUNCTION_NAME)
+		if (!renderFunction) throw Error('Render function not found in edge manifest')
+		renderFunction.pattern = dynamicRoutesPattern
+		await fs.writeFile(MANIFEST_PATH, JSON.stringify(edgeManifest))
+		builder.log(`Limited edge function to ${dynamicRoutes.length} dynamic routes`)
+	}
+	return adapterNetlify
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -36,3 +36,14 @@ export type Team = {
 	public: boolean
 	responsibilities: string[]
 }
+
+export type EdgeManifest = {
+	functions: {
+		function: string
+		path?: string
+		excludedPath?: string | string[]
+		pattern?: string
+		excludedPattern?: string | string[]
+		cache?: 'manual'
+	}[]
+}

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -1,4 +1,4 @@
-import adapter from '@sveltejs/adapter-netlify'
+import adapter from './src/lib/adapter-netlify-selective.js'
 import { vitePreprocess } from '@sveltejs/vite-plugin-svelte'
 
 import { mdsvex, escapeSvelte } from 'mdsvex'


### PR DESCRIPTION
I patched the Netlify adapter to make the edge function only handle dynamic routes, which seems to pretty consistently improve performance (including some metrics that currently "need improvement" according to PageSpeed Insights), partly because it allows Netlify to handle caching. It also reduces the number of billed function calls (which is probably negligible right now, but still) and generally seems like a better way to do things.

It would be good to test the performance on the paid account and generally make sure everything works via a Deploy Preview before merging. I'll put links to the deployments I used for testing below.

Discussion on Discord: https://discordapp.com/channels/1100491867675709580/1226136907046588476/1281710876549709836

Preview on free account:
https://adapter-netlify-selective--deft-starlight-2e4321.netlify.app/

PageSpeed Insights for preview on free account:
https://developers.google.com/speed/pagespeed/insights/?url=https://adapter-netlify-selective--deft-starlight-2e4321.netlify.app/

Current approach on free account:
https://deft-starlight-2e4321.netlify.app/

PageSpeed Insights for current approach on free account:
https://developers.google.com/speed/pagespeed/insights/?url=https://deft-starlight-2e4321.netlify.app/