### PR TITLE
Add a section called "Persuading "key nodes" in the graph/Common Knowledge" to the email-builder page

### DIFF
--- a/src/routes/email-builder/+page.svelte
+++ b/src/routes/email-builder/+page.svelte
@@ -101,8 +101,8 @@
 		<b>It's the medium for the pros.</b> Politicians, journalists, lobbyists - all of them use email.
 	</li>
 	<li>
-		<b>Persuading "key nodes" in the graph</b> "Common knowledge... we have to move it from the individual 
-                   to the group. Part of this is persuading key nodes in the graph." -- Connor Leahy 
+		<b>Persuading "key nodes" in the graph</b> "Common knowledge... we have to move it from the individual
+                   to the group. Part of this is persuading key nodes in the graph." -- Connor Leahy
                    https://youtu.be/1j--6JYRLVk?t=5716 https://youtu.be/OUjnVeydhCM?t=1969
 		   <ExternalLink
 			href={'https://youtu.be/OUjnVeydhCM?t=1969'}

--- a/src/routes/email-builder/+page.svelte
+++ b/src/routes/email-builder/+page.svelte
@@ -99,6 +99,7 @@
 	</li>
 	<li>
 		<b>It's the medium for the pros.</b> Politicians, journalists, lobbyists - all of them use email.
+		If you want to be taken seriously, you should use email too.
 	</li>
 	<li>
 		<b>Persuading "key nodes" in the graph</b> "Common knowledge... we have to move it from the individual
@@ -111,10 +112,6 @@
 			href={'https://youtu.be/1j--6JYRLVk?t=5716'}
 			>Connor Leahy - Slamming the Brakes on the AGI Arms Race (AGI Governance, Episode 5)
 	 	   </ExternalLink>
-	</li>
-	<li>
-		<b>Pros .</b> Politicians, journalists, lobbyists - all of them use email.
-		If you want to be taken seriously, you should use email too.
 	</li>
 	<li>
 		<b>No social pressure.</b> If you post something publicly, a politician might be hesitant to respond

--- a/src/routes/email-builder/+page.svelte
+++ b/src/routes/email-builder/+page.svelte
@@ -102,16 +102,17 @@
 		If you want to be taken seriously, you should use email too.
 	</li>
 	<li>
-		<b>Persuading "key nodes" in the graph</b> "Common knowledge... we have to move it from the individual
-                   to the group. Part of this is persuading key nodes in the graph." -- Connor Leahy
+		<b>Making AI Risk "common knowledge" is key.</b> We need to get everyone to know that everyone else know about AI risk, 
+                so it becomes "common knowledge". As well as, convincing influential people, like politicians, journalists, 
+                and lobbyists. (E.g. See Connor's explanation as to why making AI Risk "common knowledge" is super important, see 
 		   <ExternalLink
 			href={'https://youtu.be/OUjnVeydhCM?t=1969'}
-			>Connor Leahy on a Promising Breakthrough in AI Alignment
-	 	   </ExternalLink> 
+			>here
+	 	   </ExternalLink> and 
 		   <ExternalLink
 			href={'https://youtu.be/1j--6JYRLVk?t=5716'}
-			>Connor Leahy - Slamming the Brakes on the AGI Arms Race (AGI Governance, Episode 5)
-	 	   </ExternalLink>
+			> here
+	 	   </ExternalLink>.
 	</li>
 	<li>
 		<b>No social pressure.</b> If you post something publicly, a politician might be hesitant to respond

--- a/src/routes/email-builder/+page.svelte
+++ b/src/routes/email-builder/+page.svelte
@@ -102,12 +102,12 @@
 		If you want to be taken seriously, you should use email too.
 	</li>
 	<li>
-		<b>Making AI Risk "common knowledge" is key.</b> We need to get everyone to know that everyone else know about AI risk, 
+		<b>Making AI Risk "common knowledge" is key.</b> We need to get everyone to know that everyone else knows about AI risk, 
                 so it becomes "common knowledge". As well as, convincing influential people, like politicians, journalists, 
-                and lobbyists. (E.g. See Connor's explanation as to why making AI Risk "common knowledge" is super important, see 
+                and lobbyists. (E.g. See Connor's explanation as to why making AI Risk "common knowledge" is super important  
 		   <ExternalLink
 			href={'https://youtu.be/OUjnVeydhCM?t=1969'}
-			>here
+			> here
 	 	   </ExternalLink> and 
 		   <ExternalLink
 			href={'https://youtu.be/1j--6JYRLVk?t=5716'}

--- a/src/routes/email-builder/+page.svelte
+++ b/src/routes/email-builder/+page.svelte
@@ -103,17 +103,14 @@
 	<li>
 		<b>Persuading "key nodes" in the graph</b> "Common knowledge... we have to move it from the individual
                    to the group. Part of this is persuading key nodes in the graph." -- Connor Leahy
-		   <li><ExternalLink
+		    <ExternalLink
 			href={'https://youtu.be/OUjnVeydhCM?t=1969'}
 			>Connor Leahy on a Promising Breakthrough in AI Alignment
-	 	   </ExternalLink>
-		   </li>
- 		   <li>
+	 	   </ExternalLink> 
 		   <ExternalLink
 			href={'https://youtu.be/1j--6JYRLVk?t=5716'}
 			>Connor Leahy - Slamming the Brakes on the AGI Arms Race (AGI Governance, Episode 5)
-	 	   </ExternalLink> 
- 		   </li>
+	 	   </ExternalLink>
 	</li>
 	<li>
 		<b>Pros .</b> Politicians, journalists, lobbyists - all of them use email.

--- a/src/routes/email-builder/+page.svelte
+++ b/src/routes/email-builder/+page.svelte
@@ -98,6 +98,9 @@
 		this stuff all day.
 	</li>
 	<li>
+		<b>It's the medium for the pros.</b> Politicians, journalists, lobbyists - all of them use email.
+	</li>
+	<li>
 		<b>Persuading "key nodes" in the graph</b> "Common knowledge... we have to move it from the individual 
                    to the group. Part of this is persuading key nodes in the graph." -- Connor Leahy 
                    https://youtu.be/1j--6JYRLVk?t=5716 https://youtu.be/OUjnVeydhCM?t=1969

--- a/src/routes/email-builder/+page.svelte
+++ b/src/routes/email-builder/+page.svelte
@@ -112,7 +112,7 @@
 		   <ExternalLink
 			href={'https://youtu.be/1j--6JYRLVk?t=5716'}
 			> here
-	 	   </ExternalLink>.
+	 	   </ExternalLink>.)
 	</li>
 	<li>
 		<b>No social pressure.</b> If you post something publicly, a politician might be hesitant to respond

--- a/src/routes/email-builder/+page.svelte
+++ b/src/routes/email-builder/+page.svelte
@@ -103,7 +103,7 @@
 	<li>
 		<b>Persuading "key nodes" in the graph</b> "Common knowledge... we have to move it from the individual
                    to the group. Part of this is persuading key nodes in the graph." -- Connor Leahy
-		    <ExternalLink
+		   <ExternalLink
 			href={'https://youtu.be/OUjnVeydhCM?t=1969'}
 			>Connor Leahy on a Promising Breakthrough in AI Alignment
 	 	   </ExternalLink> 

--- a/src/routes/email-builder/+page.svelte
+++ b/src/routes/email-builder/+page.svelte
@@ -103,15 +103,17 @@
 	<li>
 		<b>Persuading "key nodes" in the graph</b> "Common knowledge... we have to move it from the individual
                    to the group. Part of this is persuading key nodes in the graph." -- Connor Leahy
-                   https://youtu.be/1j--6JYRLVk?t=5716 https://youtu.be/OUjnVeydhCM?t=1969
-		   <ExternalLink
+		   <li><ExternalLink
 			href={'https://youtu.be/OUjnVeydhCM?t=1969'}
 			>Connor Leahy on a Promising Breakthrough in AI Alignment
 	 	   </ExternalLink>
+		   </li>
+ 		   <li>
 		   <ExternalLink
 			href={'https://youtu.be/1j--6JYRLVk?t=5716'}
 			>Connor Leahy - Slamming the Brakes on the AGI Arms Race (AGI Governance, Episode 5)
 	 	   </ExternalLink> 
+ 		   </li>
 	</li>
 	<li>
 		<b>Pros .</b> Politicians, journalists, lobbyists - all of them use email.

--- a/src/routes/email-builder/+page.svelte
+++ b/src/routes/email-builder/+page.svelte
@@ -98,7 +98,20 @@
 		this stuff all day.
 	</li>
 	<li>
-		<b>It's the medium for the pros.</b> Politicians, journalists, lobbyists - all of them use email.
+		<b>Persuading "key nodes" in the graph</b> "Common knowledge... we have to move it from the individual 
+                   to the group. Part of this is persuading key nodes in the graph." -- Connor Leahy 
+                   https://youtu.be/1j--6JYRLVk?t=5716 https://youtu.be/OUjnVeydhCM?t=1969
+		   <ExternalLink
+			href={'https://youtu.be/OUjnVeydhCM?t=1969'}
+			>Connor Leahy on a Promising Breakthrough in AI Alignment
+	 	   </ExternalLink>
+		   <ExternalLink
+			href={'https://youtu.be/1j--6JYRLVk?t=5716'}
+			>Connor Leahy - Slamming the Brakes on the AGI Arms Race (AGI Governance, Episode 5)
+	 	   </ExternalLink> 
+	</li>
+	<li>
+		<b>Pros .</b> Politicians, journalists, lobbyists - all of them use email.
 		If you want to be taken seriously, you should use email too.
 	</li>
 	<li>
@@ -125,7 +138,7 @@
 	<li>
 		<b>Someone who politically represents you.</b> Maybe a politician in parliament from the party
 		that you voted for. <ExternalLink
-			href={'https://www.campaignforaisafety.org/politician/#find-your-politician-here'}
+			href={'https://github.com/Campaign-for-AI-Safety-archive/.github/tree/main/email-templates#email-your-politician'}
 			>Find their email address</ExternalLink
 		>.
 	</li>


### PR DESCRIPTION
Summary:
- Add a section called "Persuading "key nodes" in the graph" to the email-builder page
- Fix the link for "Find their email address", as it's currently broken

Note:
- I don't know how this update will look.  Please run the preview, check formatting, etc before merging to main.  Ping me on discord if the preview looks bad and I can help to fix...
- (edit) Ok, I did find an issue in the netlify preview, but I fixed and it look good now... https://deploy-preview-295--pauseai.netlify.app/email-builder Ready to verify/approve... 