### PR TITLE
Add Substack newsletter signup component

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -86,5 +86,15 @@
 	"footer_other_license": "License: CC-BY 4.0",
 	"footer_other_feedback": "Submit feedback",
 	"footer_other_edit": "Edit original English content",
-	"footer_other_l10n": "Suggest translation improvement"
+	"footer_other_l10n": "Suggest translation improvement",
+
+	"newsletter_heading": "Subscribe to our newsletter",
+	"newsletter_description": "Stay updated on our efforts to advocate for AI safety.",
+	"newsletter_disclaimer": "Our newsletter is completely free. No paid subscription necessary. You can close Substack once signed up.",
+	"newsletter_email_placeholder": "Your email",
+	"newsletter_button": "Subscribe",
+	"newsletter_success": "Thank you for subscribing!",
+	"newsletter_error_default": "Failed to subscribe. Please try again.",
+	"newsletter_error_network": "Network error. Please try again later.",
+	"newsletter_loading": "Loading..."
 }

--- a/src/lib/components/NewsletterSignup.svelte
+++ b/src/lib/components/NewsletterSignup.svelte
@@ -1,0 +1,179 @@
+<script lang="ts">
+	// NewsletterSignup.svelte - Component for newsletter subscription
+	import { browser } from '$app/environment'
+	import { onMount } from 'svelte'
+	import * as m from '$lib/paraglide/messages.js'
+
+	// Localizable text
+	export let placeholderText = m.newsletter_email_placeholder()
+	export let buttonText = m.newsletter_button()
+	export let headingText = m.newsletter_heading()
+	export let descriptionText = m.newsletter_description()
+
+	// State variables
+	let email = ''
+	let subscribeStatus: 'idle' | 'loading' | 'success' | 'error' = 'idle'
+	let errorMessage = ''
+
+	// Handle form submission - direct to Substack's subscribe page
+	const handleSubmit = () => {
+		if (!email) return
+
+		try {
+			// This is Substack's recommended way for free tier publications
+			// Open the subscribe page with the email pre-filled
+			const substackUrl = new URL('https://pauseai.substack.com/subscribe')
+			substackUrl.searchParams.append('email', email)
+			substackUrl.searchParams.append('utm_source', 'website')
+
+			// Open in new tab and show success in our UI
+			window.open(substackUrl.toString(), '_blank')
+
+			// Show success UI
+			subscribeStatus = 'success'
+			email = '' // Clear the email input
+		} catch (error) {
+			subscribeStatus = 'error'
+			errorMessage = m.newsletter_error_network()
+			console.error('Newsletter redirect error:', error)
+		}
+	}
+
+	// Reset error state when email changes
+	$: if (email && subscribeStatus === 'error') {
+		subscribeStatus = 'idle'
+		errorMessage = ''
+	}
+</script>
+
+<div class="newsletter-signup">
+	<div class="newsletter-content">
+		<h3>{headingText}</h3>
+		<p>{descriptionText}</p>
+
+		<form on:submit|preventDefault={handleSubmit}>
+			<div class="input-group">
+				<input
+					type="email"
+					name="email"
+					bind:value={email}
+					placeholder={placeholderText}
+					aria-label={placeholderText}
+					required
+				/>
+				<button type="submit">
+					{buttonText}
+				</button>
+			</div>
+
+			<p class="note">{m.newsletter_disclaimer()}</p>
+
+			{#if subscribeStatus === 'success'}
+				<div class="message success">
+					{m.newsletter_success()}
+				</div>
+			{:else if subscribeStatus === 'error'}
+				<div class="message error">
+					{errorMessage}
+				</div>
+			{/if}
+		</form>
+	</div>
+</div>
+
+<style>
+	.newsletter-signup {
+		background-color: var(--bg-subtle);
+		border-radius: 8px;
+		padding: 1.5rem;
+		margin: 2rem 0;
+		width: 100%;
+		box-sizing: border-box;
+	}
+
+	.newsletter-content {
+		max-width: 500px;
+		margin: 0 auto;
+	}
+
+	h3 {
+		margin-top: 0;
+		margin-bottom: 0.5rem;
+		font-family: var(--font-heading);
+	}
+
+	p {
+		margin-bottom: 1.5rem;
+	}
+
+	.input-group {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 8px;
+	}
+
+	.note {
+		font-size: 0.85rem;
+		margin-top: 0.5rem;
+		opacity: 0.8;
+		font-style: italic;
+	}
+
+	input {
+		flex: 1;
+		min-width: 200px;
+		padding: 0.75rem 1rem;
+		border: 1px solid var(--border);
+		border-radius: 4px;
+		font-size: 1rem;
+	}
+
+	button {
+		padding: 0.75rem 1.5rem;
+		border: none;
+		border-radius: 4px;
+		font-weight: bold;
+		cursor: pointer;
+		transition: opacity 0.2s;
+		font-size: 1rem;
+		background-color: var(--brand);
+		color: var(--bg);
+	}
+
+	button:hover {
+		opacity: 0.9;
+	}
+
+	button:disabled {
+		opacity: 0.7;
+		cursor: not-allowed;
+	}
+
+	.message {
+		margin-top: 10px;
+		padding: 8px;
+		border-radius: 4px;
+		font-size: 0.9rem;
+	}
+
+	.success {
+		background-color: #e6f7e6;
+		color: #2e7d32;
+	}
+
+	.error {
+		background-color: #fdecea;
+		color: #d50000;
+	}
+
+	@media (max-width: 600px) {
+		.input-group {
+			flex-direction: column;
+		}
+
+		input,
+		button {
+			width: 100%;
+		}
+	}
+</style>

--- a/src/posts/join.md
+++ b/src/posts/join.md
@@ -2,6 +2,7 @@
 title: Join PauseAI
 description: Sign up to join the PauseAI movement.
 ---
+
 This is our nuclear moment.
 Rapid AI advancement represents one of history's most consequential and dangerous technological shifts.
 We demand politicians and companies pause AGI development until international safety agreements are established.
@@ -16,3 +17,11 @@ The future of AI belongs to all of us.
 _Is the form below not showing? Open [this link](https://airtable.com/embed/appWPTGqZmUcs3NWu/pag7ztLh27Omj5s2n/form) instead._
 
 <iframe class="airtable-embed" src="https://airtable.com/embed/appWPTGqZmUcs3NWu/pag7ztLh27Omj5s2n/form" frameborder="0" onmousewheel="" width="100%" height="533" style="background: transparent; border: 1px solid #ccc;"></iframe>
+
+<script>
+import NewsletterSignup from '$lib/components/NewsletterSignup.svelte';
+</script>
+
+## Stay Updated
+
+<NewsletterSignup />

--- a/src/posts/learn.md
+++ b/src/posts/learn.md
@@ -3,6 +3,12 @@ title: Learn why AI safety matters
 description: Educational resources (videos, articles, books) about AI risks and AI alignment
 ---
 
+<script>
+import NewsletterSignup from '$lib/components/NewsletterSignup.svelte';
+</script>
+
+<NewsletterSignup />
+
 ## On this website
 
 - [Risks](/risks). A summary of the risks of AI.


### PR DESCRIPTION
Closes #312

## Summary
- Added a new  component for Substack newsletter subscriptions
- Implemented redirection to Substack's subscription page with pre-filled email
- Added localization strings for all component text
- Placed the component on Join and Learn pages as requested
- Added disclaimer message for transparency about the Substack redirect

## Test plan
- Test the component on different screen sizes
- Verify the subscription redirect works correctly
- Check all localization strings display properly

🤖 Generated with [Claude Code](https://claude.ai/code)