### PR TITLE
Fix: Allow class prop to pass through Link component

### DIFF
--- a/src/lib/components/custom/a.svelte
+++ b/src/lib/components/custom/a.svelte
@@ -14,6 +14,8 @@
 
 	export let href: string
 	export let target: string | null = null
+	let className: string = ''
+	export { className as class }
 
 	const ICON_PROPS = { size: '0.8em' }
 
@@ -62,7 +64,7 @@
 	})
 </script>
 
-<a {href} {target} bind:this={anchor}>
+<a {href} {target} class={className} bind:this={anchor}>
 	<slot />{#if type != Type.Internal}
 		<span style="white-space: nowrap">
 			<div class="icon">


### PR DESCRIPTION
## Summary
- Fixes #367: Enable `class` prop support for the custom Link component
- Allows styling of Link components, specifically fixing the footer's "Join" button styling

## Changes
- Add `class` prop to `src/lib/components/custom/a.svelte`
- Use `className` internally to avoid JavaScript reserved word conflict
- Export as `export { className as class }` for external API

## Impact
- Fixes missing `c2a` class styling on footer "Join" link
- Currently only affects `src/routes/footer.svelte` usage
- Future Link components can now accept class styling

## Testing
- ✅ Verified class appears in prerendered HTML
- ✅ Confirmed styling renders correctly in browser
- ✅ No impact on existing Link usage (backward compatible)

Closes #367