### PR TITLE
added pauseai mtl website link to pauseai-communities.json

### DIFF
--- a/src/routes/communities/pauseai-communities.json
+++ b/src/routes/communities/pauseai-communities.json
@@ -112,7 +112,7 @@
 			"name": "PauseAI Montreal",
 			"lat": 45.5088,
 			"lon": -73.5616,
-			"link": "$$DISCORD_GLOBAL$$"
+			"link": "https://pauseai.ca/montreal.html"
 		},
 		{
 			"name": "PauseAI Nairobi",


### PR DESCRIPTION
updated pauseai mtl link so that it links to https://pauseai.ca/montreal.html instead of international pauseai discord.