### PR TITLE
Test Spanish (es) locale support

### DIFF
--- a/L10N.md
+++ b/L10N.md
@@ -198,7 +198,7 @@ l10n-cage/
 4. **L10n is generated automatically** in CI/CD on the appropriate cage branch
 5. **Preview l10n results** in staging before merging
 
-**Current limitation**: While main branch is locked to en-only locale, target your pull requests to `l10-preview` or similar branches that have all locales enabled in order to have l10ns automatically captured.
+**Testing new locales**: To test a new locale before adding it to production, create a branch starting with `l10n` (e.g., `l10n-es` for Spanish). These branches automatically get `PARAGLIDE_LOCALES="all"` via `netlify.toml`, allowing you to preview all locales defined in `default-settings.js`.
 
 ### L10n Development
 
@@ -252,20 +252,67 @@ This lets you reuse expensive LLM-generated content across different feature bra
 
 ### Adding New Locales
 
-1. **Add locale to configuration**:
+#### Testing Before Production
+
+To test a new locale without affecting production:
+
+1. **Create a test branch** starting with `l10n`:
+
+   ```bash
+   git checkout -b l10n-fr origin/main  # For testing French
+   ```
+
+2. **Add locale to configuration**:
 
    ```javascript
    // project.inlang/default-settings.js
-   locales: ['en', 'nl', 'de', 'fr'] // Add 'fr'
+   locales: ['en', 'de', 'nl', 'fr'] // Add 'fr' to existing locales
    ```
 
-2. **Estimate work locally**:
+   Note: You can temporarily remove other non-English locales during development to speed up builds, but this makes the merge to main less straightforward.
+
+3. **Estimate work locally** (optional but recommended):
 
    ```bash
-   PARAGLIDE_LOCALES=en,fr pnpm l10n --dry-run --verbose
+   PARAGLIDE_LOCALES=all pnpm l10n --dry-run --verbose
    ```
 
-3. You could **perform it locally** or **through a pull request**
+   This shows what translations will be generated and estimated costs.
+
+4. **Push to trigger preview**:
+
+   ```bash
+   git add -A && git commit -m "Test French locale"
+   git push -u origin l10n-fr
+   ```
+
+   Netlify will build a preview with all defined locales enabled (via `netlify.toml` context).
+
+5. **The l10n cage mirrors your branch**: Translations are stored in a matching `l10n-fr` branch of the paraglide repository.
+
+#### Launching to Production
+
+Once tested, you have two options:
+
+**Option A: Fresh translations**
+
+- Merge `l10n-fr` to main
+- Production regenerates translations
+
+**Option B: Preserve tested translations**
+
+- First merge paraglide's `l10n-fr` to paraglide's main
+- Then merge website's `l10n-fr` to main
+- Production uses your tested translations
+
+#### Local Testing
+
+For local testing with API key:
+
+```bash
+PARAGLIDE_LOCALES=en,fr pnpm l10n --dry-run --verbose  # Estimate work and costs
+PARAGLIDE_LOCALES=en,fr pnpm l10n                       # Generate translations
+```
 
 ## Troubleshooting
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -24,3 +24,8 @@
 [dev]
   command = "pnpm dev"
   port = 37572
+
+# Configuration for l10n testing branches
+# Any branch starting with "l10n" will use all locales defined in default-settings.js
+[context."l10n*".environment]
+  PARAGLIDE_LOCALES = "all"

--- a/project.inlang/default-settings.js
+++ b/project.inlang/default-settings.js
@@ -7,7 +7,7 @@
 export default {
 	$schema: 'https://inlang.com/schema/project-settings',
 	baseLocale: 'en',
-	locales: ['en', 'de', 'nl'],
+	locales: ['en', 'es'],
 	modules: [
 		'https://cdn.jsdelivr.net/npm/@inlang/plugin-m-function-matcher@latest/dist/index.js',
 		'https://cdn.jsdelivr.net/npm/@inlang/plugin-message-format@latest/dist/index.js',


### PR DESCRIPTION
Testing the new l10n branch workflow for Spanish translations.

This PR:
- Adds Spanish to available locales
- Configures Netlify to enable all locales for branches starting with 'l10n'
- Updates documentation for the new locale testing workflow

The Netlify preview should show Spanish translations at /es paths.

**This is a draft PR for testing only - not intended for merge to main.**