### PR TITLE
fix: banner pushing hero below viewport fold

### DIFF
--- a/src/lib/components/Hero.svelte
+++ b/src/lib/components/Hero.svelte
@@ -116,7 +116,7 @@
 
 	.hero {
 		display: block;
-		height: 100vh;
+		height: 100%;
 		min-height: var(--hero-min-height);
 		overflow: hidden;
 		position: relative;

--- a/src/lib/components/Hero.svelte
+++ b/src/lib/components/Hero.svelte
@@ -117,7 +117,7 @@
 	.hero {
 		display: block;
 		height: 100%;
-		min-height: var(--hero-min-height);
+		min-height: min(var(--hero-min-height), 100%);
 		overflow: hidden;
 		position: relative;
 		width: 100vw;

--- a/src/lib/components/Hero.svelte
+++ b/src/lib/components/Hero.svelte
@@ -117,7 +117,6 @@
 	.hero {
 		display: block;
 		height: 100%;
-		min-height: min(var(--hero-min-height), 100%);
 		overflow: hidden;
 		position: relative;
 		width: 100vw;

--- a/src/lib/components/Hero.svelte
+++ b/src/lib/components/Hero.svelte
@@ -116,8 +116,9 @@
 
 	.hero {
 		display: block;
-		height: 100%;
-		min-height: min(var(--hero-min-height), 100%);
+		height: 100vh;
+		min-height: var(--hero-min-height);
+		max-height: 100%;
 		overflow: hidden;
 		position: relative;
 		width: 100vw;

--- a/src/lib/components/Hero.svelte
+++ b/src/lib/components/Hero.svelte
@@ -116,9 +116,8 @@
 
 	.hero {
 		display: block;
-		height: 100vh;
-		min-height: var(--hero-min-height);
-		max-height: 100%;
+		height: 100%;
+		min-height: min(var(--hero-min-height), 100%);
 		overflow: hidden;
 		position: relative;
 		width: 100vw;

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -170,9 +170,9 @@
 		top: 0;
 		left: 0;
 		right: 0;
-		/* Replicate .layout constraints: constrain to page-width minus its 3rem padding on each side,
-		   then center. This keeps --cqw container-query calculations identical to before. */
-		width: calc(min(100%, var(--page-width)) - 2 * 3rem);
+		/* Replicate the content-box width of .layout (box-sizing: content-box, max-inline-size: 40rem,
+		   padding: 0 3rem): content-box = min(page-width, viewport - 2*padding) */
+		width: min(var(--page-width), 100vw - 6rem);
 		margin-inline: auto;
 		z-index: 1;
 	}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -170,8 +170,6 @@
 		top: 0;
 		left: 0;
 		right: 0;
-		/* Replicate the content-box width of .layout (box-sizing: content-box, max-inline-size: 40rem,
-		   padding: 0 3rem): content-box = min(page-width, viewport - 2*padding) */
 		width: min(var(--page-width), 100vw - 6rem);
 		margin-inline: auto;
 		z-index: 1;

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -51,7 +51,7 @@
 	Top
 </h2>
 
-<div class="page-top" class:with-hero={hero}>
+<div class="page-top" class:hero-page={hero}>
 	<!-- Make sure we only show one banner at a time-->
 	{#if data.localeAlert}
 		<Banner
@@ -104,7 +104,7 @@
 	{/if}
 </div>
 
-<div class="layout" class:with-hero={hero}>
+<div class="layout" class:hero-page={hero}>
 	{#if $page.route.id === '/sayno'}
 		<!-- Dynamic import and render the selfie UX component -->
 		{#await import('./sayno/SelfieUX.svelte') then module}
@@ -151,13 +151,13 @@
 		margin: auto;
 	} */
 
-	.page-top.with-hero {
+	.page-top.hero-page {
 		display: flex;
 		flex-direction: column;
 		height: 100dvh;
 	}
 
-	.page-top.with-hero .hero-section {
+	.page-top.hero-page .hero-section {
 		flex: 1;
 	}
 
@@ -188,7 +188,7 @@
 		padding: 0 var(--padding-wide) 0 var(--padding-wide);
 	}
 
-	.layout.with-hero {
+	.layout.hero-page {
 		grid-template-rows: 1fr auto;
 	}
 

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -170,6 +170,10 @@
 		top: 0;
 		left: 0;
 		right: 0;
+		/* Replicate .layout constraints: constrain to page-width minus its 3rem padding on each side,
+		   then center. This keeps --cqw container-query calculations identical to before. */
+		width: calc(min(100%, var(--page-width)) - 2 * 3rem);
+		margin-inline: auto;
 		z-index: 1;
 	}
 

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -51,49 +51,58 @@
 	Top
 </h2>
 
-<!-- Make sure we only show one banner at a time-->
-{#if data.localeAlert}
-	<Banner
-		contrast={data.localeAlert.isDev}
-		id={data.localeAlert.isDev ? undefined : 'locale-switch'}
-	>
-		<!-- eslint-disable-next-line svelte/no-at-html-tags not vulnerable against XSS -->
-		{@html data.localeAlert.message}
-	</Banner>
-{:else if geo?.country?.code === 'GB'}
-	<Banner contrast={hero}>
-		<b
-			>PauseAI's largest ever protest will be on Saturday February 28th in London. <Link
-				href="https://luma.com/o0p4htmk">Sign up now!</Link
-			></b
+<div class="page-top" class:with-hero={hero}>
+	<!-- Make sure we only show one banner at a time-->
+	{#if data.localeAlert}
+		<Banner
+			contrast={data.localeAlert.isDev}
+			id={data.localeAlert.isDev ? undefined : 'locale-switch'}
 		>
-	</Banner>
-{:else}
-	<NearbyEvent contrast={hero} bind:eventFound {geo} />
-	{#if !eventFound}
-		{#if geo?.country?.code === 'US' && false}
-			<Banner contrast={hero}>
-				<b
-					>HELP US PROTECT STATE SOVEREIGNTY ON AI REGULATION | <Link
-						href="https://mstr.app/b09fa92b-1899-43a0-9d95-99cd99c9dfb2">ACT NOW »</Link
-					></b
-				>
-			</Banner>
-		{:else if false}
-			<Banner contrast={hero} target="/littlehelpers">
-				<strong>🎄 Holiday Matching Campaign!</strong> Help fund volunteer stipends for PauseAI
-				advocates. <Link href="/littlehelpers">Join the Little Helpers campaign →</Link>
-			</Banner>
+			<!-- eslint-disable-next-line svelte/no-at-html-tags not vulnerable against XSS -->
+			{@html data.localeAlert.message}
+		</Banner>
+	{:else if geo?.country?.code === 'GB'}
+		<Banner contrast={hero}>
+			<b
+				>PauseAI's largest ever protest will be on Saturday February 28th in London. <Link
+					href="https://luma.com/o0p4htmk">Sign up now!</Link
+				></b
+			>
+		</Banner>
+	{:else}
+		<NearbyEvent contrast={hero} bind:eventFound {geo} />
+		{#if !eventFound}
+			{#if geo?.country?.code === 'US' && false}
+				<Banner contrast={hero}>
+					<b
+						>HELP US PROTECT STATE SOVEREIGNTY ON AI REGULATION | <Link
+							href="https://mstr.app/b09fa92b-1899-43a0-9d95-99cd99c9dfb2">ACT NOW »</Link
+						></b
+					>
+				</Banner>
+			{:else if false}
+				<Banner contrast={hero} target="/littlehelpers">
+					<strong>🎄 Holiday Matching Campaign!</strong> Help fund volunteer stipends for PauseAI
+					advocates. <Link href="/littlehelpers">Join the Little Helpers campaign →</Link>
+				</Banner>
+			{/if}
 		{/if}
 	{/if}
-{/if}
 
-{#if deLocalizeHref($page.url.pathname) !== '/brussels-ep-protest-2026'}
-	<CampaignBanner href="/brussels-ep-protest-2026" id="brussels-ep-protest-2026">
-		<strong>Brussels, Feb 23</strong> - Join us outside the European Parliament to call for a global treaty
-		to pause frontier AI development.
-	</CampaignBanner>
-{/if}
+	{#if deLocalizeHref($page.url.pathname) !== '/brussels-ep-protest-2026'}
+		<CampaignBanner href="/brussels-ep-protest-2026" id="brussels-ep-protest-2026">
+			<strong>Brussels, Feb 23</strong> - Join us outside the European Parliament to call for a global
+			treaty to pause frontier AI development.
+		</CampaignBanner>
+	{/if}
+
+	{#if hero}
+		<div class="hero-section">
+			<Hero />
+			<Header inverted />
+		</div>
+	{/if}
+</div>
 
 <div class="layout" class:with-hero={hero}>
 	{#if $page.route.id === '/sayno'}
@@ -103,12 +112,7 @@
 		{/await}
 	{/if}
 
-	{#if hero}
-		<div class="hero-section">
-			<Hero />
-			<Header inverted />
-		</div>
-	{:else}
+	{#if !hero}
 		<Header />
 	{/if}
 
@@ -147,6 +151,16 @@
 		margin: auto;
 	} */
 
+	.page-top.with-hero {
+		display: flex;
+		flex-direction: column;
+		height: 100dvh;
+	}
+
+	.page-top.with-hero .hero-section {
+		flex: 1;
+	}
+
 	.hero-section {
 		position: relative;
 	}
@@ -170,6 +184,10 @@
 		--padding-wide: 3rem;
 		--padding-narrow: 0.5rem;
 		padding: 0 var(--padding-wide) 0 var(--padding-wide);
+	}
+
+	.layout.with-hero {
+		grid-template-rows: 1fr auto;
 	}
 
 	/* Transition to narrower padding at narrow viewports (matches navbar 600px breakpoint) */

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -176,7 +176,7 @@
 		top: 0;
 		left: 0;
 		right: 0;
-		width: min(var(--page-width), 100vw - 6rem);
+		width: min(var(--page-width), 100vw - 4rem);
 		margin-inline: auto;
 		z-index: 1;
 	}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -151,6 +151,23 @@
 		margin: auto;
 	} */
 
+	:global(:root) {
+		--gutter-max: 3rem;
+		--gutter-min: 0.5rem;
+		--page-gutter: var(--gutter-max);
+	}
+
+	/* Linearly interpolate from gutter-max (at 600px) down to gutter-min */
+	@media (max-width: 600px) {
+		:global(:root) {
+			--page-gutter: clamp(
+				var(--gutter-min),
+				calc(var(--gutter-min) + (100% - 600px + 2 * (var(--gutter-max) - var(--gutter-min))) / 2),
+				var(--gutter-max)
+			);
+		}
+	}
+
 	.page-top.hero-page {
 		display: flex;
 		flex-direction: column;
@@ -176,7 +193,7 @@
 		top: 0;
 		left: 0;
 		right: 0;
-		width: min(var(--page-width), 100vw - 6rem);
+		width: min(var(--page-width), 100% - 2 * var(--page-gutter));
 		margin-inline: auto;
 		z-index: 1;
 	}
@@ -189,30 +206,11 @@
 		grid-template-rows: auto 1fr auto;
 		grid-auto-columns: 100%;
 		margin-inline: auto;
-		--padding-wide: 3rem;
-		--padding-narrow: 0.5rem;
-		padding: 0 var(--padding-wide) 0 var(--padding-wide);
+		padding: 0 var(--page-gutter);
 	}
 
 	.layout.hero-page {
 		grid-template-rows: 1fr auto;
-	}
-
-	/* Transition to narrower padding at narrow viewports (matches navbar 600px breakpoint) */
-	@media (max-width: 600px) {
-		.layout {
-			--transition-padding-from: 600px;
-			--transition-padding-until: calc(
-				var(--transition-padding-from) - 2 * (var(--padding-wide) - var(--padding-narrow))
-			);
-			--padding-left-right: clamp(
-				var(--padding-narrow),
-				calc(var(--padding-narrow) + (100vw - var(--transition-padding-until)) / 2),
-				var(--padding-wide)
-			);
-			padding-left: var(--padding-left-right);
-			padding-right: var(--padding-left-right);
-		}
 	}
 
 	main {

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -176,7 +176,7 @@
 		top: 0;
 		left: 0;
 		right: 0;
-		width: min(var(--page-width), 100vw - 4rem);
+		width: min(var(--page-width), 100vw - 6rem);
 		margin-inline: auto;
 		z-index: 1;
 	}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -157,8 +157,14 @@
 		height: 100dvh;
 	}
 
+	.page-top.hero-page > :global(.banner),
+	.page-top.hero-page > :global(.campaign-banner) {
+		flex-shrink: 0;
+	}
+
 	.page-top.hero-page .hero-section {
 		flex: 1;
+		min-height: 0;
 	}
 
 	.hero-section {

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -181,7 +181,7 @@
 
 	.page-top.hero-page .hero-section {
 		flex: 1;
-		min-height: 0;
+		min-height: var(--hero-min-height);
 	}
 
 	.hero-section {


### PR DESCRIPTION
Fixes #661

## What

When a banner is active, the hero section (`height: 100vh`) starts below it and extends off-screen, breaking the full-viewport effect.

| Before | After |
|---|---|
| ![](https://github.com/user-attachments/assets/5a048b20-ef1f-4246-a8ef-40722a2f9597) | ![](https://github.com/user-attachments/assets/811e9743-e0f3-4fb8-b694-fc855459214d) |

**Note:** The screenshots also show how the mobile layout is incorrectly used on vertical desktop instead of the desktop layout. This will be fixed by https://github.com/PauseAI/pauseai-website/issues/668

## How

Key changes:

- **New `page-top` wrapper** wraps banners and (on hero pages) `hero-section`. On hero pages it becomes a `height: 100dvh` flex column, so its children share the full viewport height.
- **Banners moved inside `page-top`** (previously they were in normal flow above `.layout`). They take their natural height, leaving the rest for the hero.
- **`hero-section` moved out of `.layout`** and into `page-top`, where it gets `flex: 1` to fill whatever space the banners don't use. `Hero` height changed from `100vh` to `100%` to fill its flex parent. `min-height: var(--hero-min-height)` prevents content overlap when many banners shrink the available space.
- **Shared `--page-gutter` variable on `:root`** -- the responsive padding (3rem, shrinking to 0.5rem below 600px) was previously scoped to `.layout`. Moving the hero nav out of `.layout` into full-width `page-top` meant it lost its inherited width constraint. Rather than hardcoding the padding value, the gutter is now a shared CSS variable used by both `.layout` (as padding) and the hero nav (in its width calculation: `min(var(--page-width), 100% - 2 * var(--page-gutter))`). The variables were renamed from `--padding-wide`/`--padding-narrow` to `--gutter-max`/`--gutter-min` since they now serve both padding and width purposes.
- **Flex overflow fix** -- `flex-shrink: 0` on banner elements prevents them from being squished to zero height by the hero image's intrinsic size on wide viewports (Firefox).

**Before (hero page):**
```svelte
<BannerOrNearbyEvent />           <!-- normal flow, pushes layout down -->
<CampaignBanner />                <!-- normal flow, pushes layout down -->
<div class="layout hero-page">
  <div class="hero-section">      <!-- position: relative -->
    <Hero />                      <!-- height: 100vh — overflows viewport -->
    <Header />                    <!-- nav: position: absolute over hero -->
  </div>
  <main /><Footer />
</div>
```

**After (hero page):**
```svelte
<div class="page-top hero-page">  <!-- NEW: height: 100dvh; flex column -->
  <BannerOrNearbyEvent />         <!-- takes natural height -->
  <CampaignBanner />              <!-- takes natural height -->
  <div class="hero-section">      <!-- flex: 1; min-height: var(--hero-min-height); position: relative -->
    <Hero />                      <!-- height: 100% — fills remaining space -->
    <Header />                    <!-- nav: position: absolute, width constrained via --page-gutter -->
  </div>
</div>
<div class="layout hero-page">    <!-- hero-section moved to page-top -->
  <main /><Footer />
</div>
```

## Testing

- [ ] Homepage with active banner: hero bottom at viewport fold at scroll position 0
- [ ] Dismiss banner: hero expands to fill full `100dvh`
- [ ] Resize viewport: hero adjusts without JS
- [ ] Nav width consistent between homepage and other pages at all viewport widths (especially below 600px)
- [ ] Non-hero pages: layout unchanged
- [ ] Wide viewport (2560px+) with banner: banner visible, hero fills remaining space (Firefox)
- [ ] Small viewport with many banners: hero content doesn't overlap