### PR TITLE
Highlight terms in search result titles

### DIFF
--- a/src/lib/components/Search.svelte
+++ b/src/lib/components/Search.svelte
@@ -11,6 +11,43 @@
 		}[]
 	}
 
+	const escapeRegExp = (value: string) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+
+	const escapeHtml = (value: string) =>
+		value.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+
+	const unicodeWordCharClass = '\\p{L}\\p{N}\\p{M}_'
+
+	const buildHighlightRegex = (terms: string[]) => {
+		// This uses a Unicode-aware approximation of Pagefind's title matching, but may
+		// not exactly match Pagefind's own normalization behavior for every locale or query.
+		const termPattern = terms
+			.map((term) => `${escapeRegExp(term)}[${unicodeWordCharClass}]*`)
+			.join('|')
+
+		return new RegExp(`(^|[^${unicodeWordCharClass}])(${termPattern})`, 'giu')
+	}
+
+	const highlightTitle = (text: string, regex: RegExp) => {
+		regex.lastIndex = 0
+		let highlighted = ''
+		let lastIndex = 0
+
+		for (const match of text.matchAll(regex)) {
+			const prefix = match[1] ?? ''
+			const matchedTerm = match[2]
+			const matchIndex = match.index ?? 0
+			const termIndex = matchIndex + prefix.length
+
+			highlighted += escapeHtml(text.slice(lastIndex, matchIndex))
+			highlighted += escapeHtml(prefix)
+			highlighted += `<mark>${escapeHtml(matchedTerm)}</mark>`
+			lastIndex = termIndex + matchedTerm.length
+		}
+
+		return highlighted + escapeHtml(text.slice(lastIndex))
+	}
+
 	onMount(() => {
 		new PagefindUI({
 			element: '#search',
@@ -19,7 +56,7 @@
 			processResult: function (result: Result) {
 				result.url = result.url.replace(/(.*)\.html/, '$1')
 				for (const subResult of result.sub_results) {
-					subResult.url = subResult.url.replace(/(.*).html(#.*)?/, '$1$2')
+					subResult.url = subResult.url.replace(/(.*)\.html(#.*)?/, '$1$2')
 				}
 			}
 		})
@@ -31,34 +68,35 @@
 		input.focus()
 
 		// Pagefind highlights matches in excerpts but not in result titles.
-		// Re-runs after every DOM update to inject <mark> tags into title links.
-		const observer = new MutationObserver(() => {
+		// Re-runs on query changes and after Pagefind updates the results DOM.
+		const updateTitleHighlights = () => {
 			const query = input.value.trim()
-			if (!query) return
-			const terms = query.split(/\s+/).sort((a, b) => b.length - a.length)
-			if (!terms.length) return
-			const termPattern = terms
-				.map((t) => t.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') + '\\w*')
-				.join('|')
-			const regex = new RegExp(`\\b(${termPattern})`, 'gi')
+			const terms = query.split(/\s+/).filter(Boolean)
+			const regex = terms.length ? buildHighlightRegex(terms) : null
 			for (const link of container.querySelectorAll<HTMLAnchorElement>(
 				'.pagefind-ui__result-link'
 			)) {
 				const text = link.textContent ?? ''
-				const highlighted = text
-					.split(regex)
-					.map((part, i) => {
-						const escaped = part.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
-						return i % 2 === 1 ? `<mark>${escaped}</mark>` : escaped
-					})
-					.join('')
+				if (!regex) {
+					const plainText = escapeHtml(text)
+					if (link.innerHTML !== plainText) link.innerHTML = plainText
+					continue
+				}
+
+				const highlighted = highlightTitle(text, regex)
 				if (link.innerHTML !== highlighted) link.innerHTML = highlighted
 			}
-		})
+		}
+
+		const observer = new MutationObserver(updateTitleHighlights)
+		input.addEventListener('input', updateTitleHighlights)
 
 		observer.observe(container, { childList: true, subtree: true })
 
-		return () => observer.disconnect()
+		return () => {
+			observer.disconnect()
+			input.removeEventListener('input', updateTitleHighlights)
+		}
 	})
 </script>
 

--- a/src/lib/components/Search.svelte
+++ b/src/lib/components/Search.svelte
@@ -23,8 +23,42 @@
 				}
 			}
 		})
-		const input = document.getElementsByClassName('pagefind-ui__search-input')[0] as HTMLElement
+
+		const container = document.getElementById('search')!
+		const input = container.getElementsByClassName(
+			'pagefind-ui__search-input'
+		)[0] as HTMLInputElement
 		input.focus()
+
+		// Pagefind highlights matches in excerpts but not in result titles.
+		// Re-runs after every DOM update to inject <mark> tags into title links.
+		const observer = new MutationObserver(() => {
+			const query = input.value.trim()
+			if (!query) return
+			const terms = query.split(/\s+/).sort((a, b) => b.length - a.length)
+			if (!terms.length) return
+			const termPattern = terms
+				.map((t) => t.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') + '\\w*')
+				.join('|')
+			const regex = new RegExp(`\\b(${termPattern})`, 'gi')
+			for (const link of container.querySelectorAll<HTMLAnchorElement>(
+				'.pagefind-ui__result-link'
+			)) {
+				const text = link.textContent ?? ''
+				const highlighted = text
+					.split(regex)
+					.map((part, i) => {
+						const escaped = part.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+						return i % 2 === 1 ? `<mark>${escaped}</mark>` : escaped
+					})
+					.join('')
+				if (link.innerHTML !== highlighted) link.innerHTML = highlighted
+			}
+		})
+
+		observer.observe(container, { childList: true, subtree: true })
+
+		return () => observer.disconnect()
 	})
 </script>
 


### PR DESCRIPTION
## Summary

This PR makes search results easier to scan by highlighting matched query terms in result titles, so title matching is visually consistent with the excerpt highlighting that Pagefind already provides.

It adds a title-highlighting pass in `Search.svelte` that runs both when the query changes and when Pagefind updates the results DOM. Pagefind highlights terms in result excerpts via `{@html}` but renders titles as plain text, so this patch post-processes title links to add `<mark>` tags for the current query.

## Notes

- HTML escaping is applied per-segment after splitting matches from surrounding text, so title text stays safe when written back through `innerHTML`.
- Matching is Unicode-aware, so searches involving titles like `Español`, `Zürich`, or `São Paulo` highlight correctly instead of stopping at ASCII-only word boundaries.
- The title-highlighting regex is still an approximation of Pagefind's own normalization and matching behavior, so edge cases may not exactly mirror excerpt highlighting for every locale or query.
- The title-highlighting pass reruns on query input as well as DOM mutations, which prevents stale highlights when the visible result DOM does not change between searches.
- Partial query matches still highlight the full word (for example, typing `anyo` highlights `anyone`), consistent with how Pagefind highlights matches in excerpts.

## Screenshots

**Query: "lobbying guide"**
| Before | After |
|--------|-------|
| <img alt="before-lobbying-guide" src="https://raw.githubusercontent.com/RisingOrange/pauseai-website/main/.github/pr-screenshots/cropped-before-lobbying-guide.png" /> | <img alt="after-lobbying-guide" src="https://raw.githubusercontent.com/RisingOrange/pauseai-website/main/.github/pr-screenshots/cropped-after-lobbying-guide.png" /> |

**Query: "if anyone"**
| Before | After |
|--------|-------|
| <img alt="before-if-anyone" src="https://raw.githubusercontent.com/RisingOrange/pauseai-website/main/.github/pr-screenshots/cropped-before-if-anyone.png" /> | <img alt="after-if-anyone" src="https://raw.githubusercontent.com/RisingOrange/pauseai-website/main/.github/pr-screenshots/cropped-after-if-anyone.png" /> |

**Query: "if anyo" (partial word; highlights full word "anyone")**
| Before | After |
|--------|-------|
|  | <img alt="after-if-anyo" src="https://raw.githubusercontent.com/RisingOrange/pauseai-website/main/.github/pr-screenshots/cropped-after-if-anyo.png" /> |
