### PR TITLE
Move banner rules to +layout.svelte

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -65,6 +65,33 @@
 </script>
 
 <svelte:head>
+	<script>
+		var mainBannerRules = [
+			{
+				id: 'gb-feb28-protest',
+				countries: ['GB'],
+				dateRange: [null, '2025-02-28']
+			},
+			{
+				id: 'us-state-sovereignty',
+				countries: ['US'],
+				dateRange: [null, '2025-02-28']
+			},
+			{
+				id: 'holiday-littlehelpers',
+				countries: null,
+				dateRange: [null, '2024-12-31']
+			}
+		]
+
+		var campaignBannerRules = [
+			{
+				id: 'brussels-ep-protest-2026',
+				dateRange: [null, '2026-02-23']
+			}
+		]
+	</script>
+
 	<!-- eslint-disable-next-line svelte/no-at-html-tags not vulnerable against XSS -->
 	{@html `<${'script'}>${bannerSelection}</script>`}
 </svelte:head>

--- a/src/routes/banner-selection.cjs
+++ b/src/routes/banner-selection.cjs
@@ -1,3 +1,4 @@
+/* global mainBannerRules, campaignBannerRules */
 // Banner selection: picks the active main banner and campaign banner before first paint.
 // Reads geo from cookie, checks dates + dismissals, sets data-active-banner,
 // data-is-active-banner-geo, and data-active-campaign-banner on <html>.
@@ -28,31 +29,6 @@ window.selectBanners = function () {
 		}
 		return true
 	}
-
-	var mainBannerRules = [
-		{
-			id: 'gb-feb28-protest',
-			countries: ['GB'],
-			dateRange: [null, '2025-02-28']
-		},
-		{
-			id: 'us-state-sovereignty',
-			countries: ['US'],
-			dateRange: [null, '2025-02-28']
-		},
-		{
-			id: 'holiday-littlehelpers',
-			countries: null,
-			dateRange: [null, '2024-12-31']
-		}
-	]
-
-	var campaignBannerRules = [
-		{
-			id: 'brussels-ep-protest-2026',
-			dateRange: [null, '2026-02-23']
-		}
-	]
 
 	function findActiveBannerRule(rules, dismissalPrefix) {
 		return rules.find(function (rule) {


### PR DESCRIPTION
Follow-up to #695.

Moves the banner rule definitions out of `banner-selection.cjs` and into `+layout.svelte` as an inline `<script>` in `<svelte:head>`, injected before the selection script. `banner-selection.cjs` becomes a generic utility with no banner-specific data. Adding a new banner only requires touching `+layout.svelte` (component, `data-banner-id`, and rule in one place).