### PR TITLE
Fix geo country cookie TypeError

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -36,7 +36,7 @@
 	onMount(async () => {
 		const response = await fetch('/api/geo')
 		if (!response.ok) return
-		const geo = await response.json()
+		const geo: GeoApiResponse = await response.json()
 
 		// Keep geo cookie in sync with actual location.
 		// Re-run selectBanners if country changed or cookie not yet set.

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -41,10 +41,10 @@
 		// Keep geo cookie in sync with actual location.
 		// Re-run selectBanners if country changed or cookie not yet set.
 		const geoCountryCookie = new Cookie(document.cookie).get('geo_country')
-		if (geo?.country && geo.country !== geoCountryCookie) {
+		if (geo?.country?.code && geo.country.code !== geoCountryCookie) {
 			document.cookie = new SetCookie({
 				name: 'geo_country',
-				value: geo.country,
+				value: geo.country.code,
 				path: '/',
 				maxAge: 31536000,
 				sameSite: 'Lax'


### PR DESCRIPTION
`geo.country` from Netlify's edge function context is an object `{ code?: string; name?: string }`, not a string. This caused two bugs introduced in #695:

- **TypeError in production**: Passing the object as `SetCookie`'s `value` caused `quote()` to call `.includes()` on an object → `TypeError: t.includes is not a function`
- **Cookie reset on every page load**: Comparing the object to the string cookie value always evaluated to `true`, so the cookie was re-set and `selectBanners()` was called on every page visit

## Fix
Use `geo.country.code` (the string country code) instead of `geo.country` in both the comparison and the cookie value.

## Test plan

The geo API returns 501 in dev (no Netlify platform), so these can only be verified on a deploy preview:

- [ ] No `TypeError: t.includes is not a function` in the console
- [ ] The `geo_country` cookie is set to a country code string (e.g. `"US"`), not `[object Object]`
