### PR TITLE
Inject per-post CSS links to eliminate FOUC on Markdown posts

### DIFF
--- a/src/routes/[slug]/+page.server.ts
+++ b/src/routes/[slug]/+page.server.ts
@@ -3,7 +3,5 @@ import type { PageServerLoad } from './$types'
 import { cssForPost } from './post-css.server'
 
 export const load: PageServerLoad = ({ params: { slug } }) => {
-	const locale = getLocale()
-	const src = locale === 'en' ? `src/posts/${slug}.md` : `l10n-cage/md/${locale}/${slug}.md`
-	return { cssUrls: cssForPost(src) }
+	return { cssUrls: cssForPost(slug, getLocale()) }
 }

--- a/src/routes/[slug]/+page.server.ts
+++ b/src/routes/[slug]/+page.server.ts
@@ -1,0 +1,9 @@
+import { getLocale } from '$lib/paraglide/runtime'
+import type { PageServerLoad } from './$types'
+import { cssForPost } from './post-css.server'
+
+export const load: PageServerLoad = ({ params: { slug } }) => {
+	const locale = getLocale()
+	const src = locale === 'en' ? `src/posts/${slug}.md` : `l10n-cage/md/${locale}/${slug}.md`
+	return { cssUrls: cssForPost(src) }
+}

--- a/src/routes/[slug]/+page.svelte
+++ b/src/routes/[slug]/+page.svelte
@@ -14,6 +14,12 @@
 	$: metaImageUrl = getPostMetaImageUrl(image)
 </script>
 
+<svelte:head>
+	{#each data.cssUrls ?? [] as href}
+		<link rel="stylesheet" {href} />
+	{/each}
+</svelte:head>
+
 <PostMeta {title} {description} {date} image={metaImageUrl} />
 
 <article>

--- a/src/routes/[slug]/+page.ts
+++ b/src/routes/[slug]/+page.ts
@@ -3,14 +3,14 @@ import { getLocale } from '$lib/paraglide/runtime'
 import type { PageLoad } from './$types'
 import { asError } from '$lib/utils'
 
-export const load: PageLoad = async ({ params: { slug }, depends, data }) => {
+export const load: PageLoad = async ({ params: { slug }, depends, data: serverData }) => {
 	depends('paraglide:lang')
 	try {
 		const locale = getLocale()
 		const { default: content, metadata: meta = {} } = await importMarkdown(locale, slug)
 
 		return {
-			...data,
+			...serverData,
 			content,
 			meta,
 			slug

--- a/src/routes/[slug]/+page.ts
+++ b/src/routes/[slug]/+page.ts
@@ -3,13 +3,14 @@ import { getLocale } from '$lib/paraglide/runtime'
 import type { PageLoad } from './$types'
 import { asError } from '$lib/utils'
 
-export const load: PageLoad = async ({ params: { slug }, depends }) => {
+export const load: PageLoad = async ({ params: { slug }, depends, data }) => {
 	depends('paraglide:lang')
 	try {
 		const locale = getLocale()
 		const { default: content, metadata: meta = {} } = await importMarkdown(locale, slug)
 
 		return {
+			...data,
 			content,
 			meta,
 			slug

--- a/src/routes/[slug]/post-css.server.ts
+++ b/src/routes/[slug]/post-css.server.ts
@@ -1,0 +1,49 @@
+// Reads the Vite client manifest to find which CSS files a given post's module
+// tree depends on, so we can inject <link rel="stylesheet"> tags into the
+// prerendered HTML. Without this, component CSS inside .md files loads only
+// after hydration (dynamic chunk boundary), causing a flash of unstyled content.
+//
+// Manifest shape docs: https://vite.dev/guide/backend-integration.html
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+interface ManifestEntry {
+	file: string
+	css?: string[]
+	imports?: string[]
+}
+
+type Manifest = Record<string, ManifestEntry>
+
+let cachedManifest: Manifest | null | undefined
+
+function loadManifest(): Manifest | null {
+	if (cachedManifest !== undefined) return cachedManifest
+	try {
+		// kit.outDir defaults to .svelte-kit; Vite writes its manifest inside
+		// the client build output at .vite/manifest.json.
+		const path = join(process.cwd(), '.svelte-kit/output/client/.vite/manifest.json')
+		cachedManifest = JSON.parse(readFileSync(path, 'utf-8')) as Manifest
+	} catch {
+		// Dev mode or manifest unavailable — no FOUC to fix there anyway.
+		cachedManifest = null
+	}
+	return cachedManifest
+}
+
+export function cssForPost(postSrc: string): string[] {
+	const manifest = loadManifest()
+	if (!manifest) return []
+	const seen = new Set<string>()
+	const css = new Set<string>()
+	function walk(key: string) {
+		if (seen.has(key)) return
+		seen.add(key)
+		const entry = manifest![key]
+		if (!entry) return
+		for (const c of entry.css ?? []) css.add(c)
+		for (const imp of entry.imports ?? []) walk(imp)
+	}
+	walk(postSrc)
+	return [...css].map((c) => `/${c}`)
+}

--- a/src/routes/[slug]/post-css.server.ts
+++ b/src/routes/[slug]/post-css.server.ts
@@ -3,7 +3,7 @@
 // prerendered HTML. Without this, component CSS inside .md files loads only
 // after hydration (dynamic chunk boundary), causing a flash of unstyled content.
 //
-// Manifest shape docs: https://vite.dev/guide/backend-integration.html
+// Manifest shape: https://vite.dev/guide/backend-integration.html
 import { readFileSync } from 'node:fs'
 import { join } from 'node:path'
 
@@ -20,8 +20,6 @@ let cachedManifest: Manifest | null | undefined
 function loadManifest(): Manifest | null {
 	if (cachedManifest !== undefined) return cachedManifest
 	try {
-		// kit.outDir defaults to .svelte-kit; Vite writes its manifest inside
-		// the client build output at .vite/manifest.json.
 		const path = join(process.cwd(), '.svelte-kit/output/client/.vite/manifest.json')
 		cachedManifest = JSON.parse(readFileSync(path, 'utf-8')) as Manifest
 	} catch {
@@ -31,19 +29,23 @@ function loadManifest(): Manifest | null {
 	return cachedManifest
 }
 
-export function cssForPost(postSrc: string): string[] {
+function manifestKey(slug: string, locale: string): string {
+	return locale === 'en' ? `src/posts/${slug}.md` : `l10n-cage/md/${locale}/${slug}.md`
+}
+
+export function cssForPost(slug: string, locale: string): string[] {
 	const manifest = loadManifest()
 	if (!manifest) return []
 	const seen = new Set<string>()
 	const css = new Set<string>()
-	function walk(key: string) {
-		if (seen.has(key)) return
-		seen.add(key)
-		const entry = manifest![key]
+	const walk = (k: string) => {
+		if (seen.has(k)) return
+		seen.add(k)
+		const entry = manifest[k]
 		if (!entry) return
-		for (const c of entry.css ?? []) css.add(c)
+		for (const c of entry.css ?? []) css.add(`/${c}`)
 		for (const imp of entry.imports ?? []) walk(imp)
 	}
-	walk(postSrc)
-	return [...css].map((c) => `/${c}`)
+	walk(manifestKey(slug, locale))
+	return [...css]
 }


### PR DESCRIPTION
Fixes FOUC for Svelte components used inside `src/posts/*.md`. Spotted on #778 (thanks @Wituareard for flagging the root cause).

## The bug

Markdown posts are loaded via a dynamic `import()` in `src/routes/[slug]/+page.ts`. That import boundary means any component imported inside a `.md` file lives in its own async chunk — so its CSS file isn't in the `[slug]` route's CSS manifest, and isn't linked in the prerendered HTML. The browser renders the post markup with unstyled components, then hydration kicks in and Vite injects the `<link>` at runtime, causing a visible flash / layout shift. (Visible for example on `/donate` — the donate button jumps from left-aligned to centered on load.)

## The fix

- `+page.server.ts` reads the Vite client manifest (`.svelte-kit/output/client/.vite/manifest.json`) at SSR time, walks the transitive `imports` graph starting from the post's source path, and returns the list of CSS asset URLs.
- `+page.svelte` injects a `<link rel="stylesheet">` for each via `<svelte:head>`.
- `+page.ts` spreads the server load's data through so the URLs reach the component.

Each post ends up linking exactly the CSS it needs — no manual component list to maintain, no bundle bloat.

## Test plan

- [x] `pnpm build && pnpm preview`, open `/donate` — no button jump.
- [x] Compared before/after build output: e.g. `donate.html` now links `donate.css` + `mdsvex.css`; `join.html` adds `NewsletterSignup.css` + `TallyEmbed.css`.
- [x] `pnpm check` passes.
- [x] Lint: no new errors; pre-existing warnings only.

## Notes / caveats

- Only affects prerendered HTML (which is how all posts render today). If any slug ever moves to SSR-on-demand, the Netlify function bundle would need to include the manifest file — worth a follow-up if that comes up.
- Dev mode has no manifest; the helper returns `[]` (dev doesn't have FOUC anyway since Vite injects styles via JS).