### PR TITLE
Prioritize hero image to reduce cold-load flash

### DIFF
--- a/src/lib/components/Hero.svelte
+++ b/src/lib/components/Hero.svelte
@@ -25,7 +25,7 @@
 		{#each Object.entries(homeHeroDesktop.sources) as [format, srcset]}
 			<source {srcset} sizes="100vw" type={'image/' + format} />
 		{/each}
-		<img src={homeHeroDesktop.img.src} alt="" />
+		<img src={homeHeroDesktop.img.src} alt="" fetchpriority="high" />
 	</picture>
 	<div class="content" bind:this={tagline}>
 		<h2>Don't let AI companies<br />gamble away our future</h2>


### PR DESCRIPTION
The hero `<img>` is the largest visible thing above the fold on `/`, but in prod DevTools shows it being fetched at *Low* priority on cold loads, which is why it visibly pops in late after CSS, fonts, and other resources settle. `fetchpriority="high"` moves it earlier in the priority queue.

## Cold-load flash before the fix

<video controls aria-label="Cold-load flash: hero image briefly missing before fading in" src="https://github.com/user-attachments/assets/d3214fe6-4041-433d-b8b9-b629876dcbdc"></video>

Recorded via hard-refresh on a fast connection, so the gap is short. On a true cold visit (no cached resources, cold CDN edge, slower network) the gap is noticeably longer.

The flash won't disappear entirely — `fetchpriority` shrinks the gap, it doesn't make the image free — but on warm caches / fast networks it should be imperceptible.