### PR TITLE
Fix homepage hero not filling viewport

### DIFF
--- a/src/lib/components/Hero.svelte
+++ b/src/lib/components/Hero.svelte
@@ -56,22 +56,16 @@
 	.hero {
 		position: relative;
 		width: 100vw;
+		flex: 1;
 		left: 50%;
 		transform: translateX(-50%);
 		background-color: #ff9416;
 		isolation: isolate;
+		overflow: hidden;
 		color: white;
 
-		/* Desktop hero image aspect ratio (2880 / 1600) — update if image changes */
-		--hero-img-ar: 1.8;
 		/* Adjust this to push the mobile image up or down (e.g., 0px, 10vh, -20px) */
 		--mobile-hero-img-pos: 215px;
-	}
-
-	/* Protest photo — spans the full hero behind both sections, soft-light
-	   blended into the orange background. */
-	.hero {
-		overflow: hidden;
 	}
 
 	.hero-photo {
@@ -170,6 +164,11 @@
 		background: #fe9414;
 		flex-shrink: 0;
 		animation: heroPulse 1.8s ease-in-out infinite;
+	}
+	@media (prefers-reduced-motion: reduce) {
+		.hero-badge-dot {
+			animation: none;
+		}
 	}
 	@keyframes heroPulse {
 		0%,

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -252,6 +252,8 @@
 	.page-top.hero-page .hero-section {
 		flex: 1;
 		min-height: var(--hero-min-height);
+		display: flex;
+		flex-direction: column;
 	}
 
 	.hero-section {


### PR DESCRIPTION
Restores the homepage hero stretching to the bottom of the viewport on screens taller than the hero's content, which regressed in #850.

## Cause
#850 switched `.page-top.hero-page` from `height: 100dvh` to `min-height: 100dvh` (so the new taller hero can grow when its content needs more room), and the rewritten `.hero` element no longer set `height: 100%`. On viewports taller than the hero's intrinsic content, `.hero-section` (which is `flex: 1`) grew to fill the page-top but the `.hero` block inside it stayed content-sized, so the section below leaked through the gap at the bottom of the fold.

## Fix
Make `.hero-section` a flex column container and give `.hero` `flex: 1`, so it stretches to fill whatever space the flex algorithm gives it, while still allowing the hero to grow past 100dvh when content is taller (the reason #850 switched to `min-height`).

### Small cleanups in the same file
- Removed the dead `--hero-img-ar` CSS var (carried over from the previous hero implementation, not referenced by any rule after #850).
- Merged two adjacent `.hero { ... }` blocks into one.
- Gated the active-campaign badge dot pulse on `@media (prefers-reduced-motion: reduce)` — #850's own test plan flagged this as a TODO.

## Before / after

### Desktop (1440×1100)

<table><tr>
<td valign="top"><b>Before</b><br><img width="400" alt="Before fix: hero ends partway down the viewport, next section's protest image visible at the bottom" src="https://github.com/user-attachments/assets/4f8d5087-fd53-4ca6-9923-651e3e97e882" /></td>
<td valign="top"><b>After</b><br><img width="400" alt="After fix: hero fills the full viewport" src="https://github.com/user-attachments/assets/505f729c-3b8a-4534-805b-286b8f0ee352" /></td>
</tr></table>

### Tall viewport (half-4K, 1920×2160)

The bug is most pronounced on tall viewports — e.g. a browser taking half the width of a 4K monitor. Before the fix the hero ends about a third of the way down the viewport; after the fix it fills it. Caveat: the protester image gets noticeably more zoomed at this size, since the hero photo is `height: 100%` and the hero is now much taller — this is a pre-existing #850 image-treatment artifact that a further design pass is planned to address (light-grey campaign section, smaller heading, replaced photo).

<table><tr>
<td valign="top"><b>Before</b><br><img width="350" alt="Before fix at half-4K (1920×2160): hero ends ~1/3 down, rest of viewport is empty" src="https://github.com/user-attachments/assets/8dd56df2-81b1-4bf5-b0f5-e9d12b1a6a03" /></td>
<td valign="top"><b>After</b><br><img width="350" alt="After fix at half-4K (1920×2160): hero fills the viewport; image is more zoomed at this size (pre-existing #850 design)" src="https://github.com/user-attachments/assets/06ec3f43-18e3-45be-8b57-2aa3dd6dd9c0" /></td>
</tr></table>

### Mobile (390×844)

Unaffected — the hero's content already exceeds the viewport at this size, so the layout was already content-sized before this fix and the change is a no-op.

<img width="250" alt="Mobile (390×844): hero content already exceeds the viewport, layout unchanged by this fix" src="https://github.com/user-attachments/assets/f62ce518-5084-4864-a931-9ea74c08954c" />

## Known issues from #850 not addressed here

Surfaced while testing, scoped out so this PR stays minimal. A further design pass is already planned to address these (light-grey campaign section to differentiate it from the top, smaller campaign heading, replaced photo):

- Mobile vertical overflow: `.hero-top-inner` has `padding: 14rem 1.5rem 2rem` and `.hero-top { min-height: 420px }`, which combined with the campaign section pushes the campaign CTAs well below the fold on most phones.
- Megaphone protester overlaps the h1 text on tall portrait-ish desktop viewports (e.g. 4K half-monitor) because of the right-anchored, height-based image sizing.

## Test plan
- [ ] Desktop 1440×1100, 1920×1080: hero fills the viewport, no gap to the next section.
- [ ] Mobile 390×844: unchanged.
- [ ] Viewports where hero content > 100dvh: hero grows past the viewport (campaign section appears on scroll, no clipping).





