### PR TITLE
Write Parliament-visit attendance to Airtable

### DIFF
--- a/src/lib/components/UKMPEmailForm.svelte
+++ b/src/lib/components/UKMPEmailForm.svelte
@@ -190,7 +190,8 @@ ${userPostcode.toUpperCase()}`)
 					senderPostcode: userPostcode,
 					recipient: mp.email,
 					subject: subject.trim(),
-					message: message.trim()
+					message: message.trim(),
+					attendingVisit
 				})
 			})
 

--- a/src/lib/components/UKMPEmailForm.svelte
+++ b/src/lib/components/UKMPEmailForm.svelte
@@ -259,9 +259,9 @@ ${userPostcode.toUpperCase()}`)
 						onchange={toggleVisit}
 					/>
 					<span class="visit-text">
-						I will be attending PauseAI UK's
+						I will attend PauseAI UK's
 						<Link href="https://luma.com/q2wu0y59?utm_source=uk-email-builder" target="_blank"
-							>visit to Parliament</Link
+							>visit to Parliament on 23<sup>rd</sup> June</Link
 						> to speak with my MP in person.
 					</span>
 				</label>

--- a/src/routes/api/uk-send-mp-email/+server.ts
+++ b/src/routes/api/uk-send-mp-email/+server.ts
@@ -39,6 +39,7 @@ interface EmailRequest {
 	recipient: string
 	subject: string
 	message: string
+	attendingVisit?: boolean
 }
 
 type UKSendMPEmailApiSuccessResponse = {
@@ -163,7 +164,8 @@ export const POST: RequestHandler = async ({ request }) => {
 				Recipient: [mpRecordId], // Array of record IDs for linked field
 				Subject: data.subject,
 				Message: data.message,
-				Campaign: 'Liability letter'
+				Campaign: 'Liability letter',
+				'Attending Parliament 23 June 2026': data.attendingVisit ?? false
 			}
 		}
 


### PR DESCRIPTION
The UK MP email form already has a checkbox for users planning to attend PauseAI UK's June 23rd visit to Parliament (added in #877). This PR plumbs the checkbox state through to the Web Form Emails table.

On submit, the form now sends \`attendingVisit: boolean\` in the JSON payload. The API endpoint writes it to the new \`Attending visit to Parliament 23 June\` checkbox column on \`tblkzjrRHiZiqMDGR\`.

Replaces #885 (which was opened from a branch with merged-but-unsquashed history; this one is cherry-picked clean onto current main).