### PR TITLE
Remove the Parliament-visit checkbox from the UK email builder

### DIFF
--- a/src/lib/components/UKMPEmailForm.svelte
+++ b/src/lib/components/UKMPEmailForm.svelte
@@ -45,34 +45,6 @@ ${userPostcode.toUpperCase()}`)
 	let errorMessage = $state('')
 	let confirmingSend = $state(false)
 
-	let attendingVisit = $state(false)
-	let messageBeforeVisit: string | null = $state(null)
-
-	const ORIGINAL_NEXT_STEPS = `Please could we arrange a short meeting to discuss this important matter?`
-
-	const VISIT_SENTENCE = `**I will be visiting Parliament on Tuesday June 23rd between 1pm and 4pm. Will you meet with me to discuss the letter and your plan for addressing AI risks?**`
-
-	function toggleVisit() {
-		if (attendingVisit) {
-			messageBeforeVisit = message
-			if (message.includes(ORIGINAL_NEXT_STEPS)) {
-				message = message.replace(ORIGINAL_NEXT_STEPS, VISIT_SENTENCE)
-			} else {
-				// User has customised the Next steps section. Insert the visit sentence
-				// before the signature line so we don't trample their edits.
-				const signatureMarker = '\nThank you for your consideration'
-				if (message.includes(signatureMarker)) {
-					message = message.replace(signatureMarker, `\n${VISIT_SENTENCE}\n${signatureMarker}`)
-				} else {
-					message = `${message}\n\n${VISIT_SENTENCE}`
-				}
-			}
-		} else if (messageBeforeVisit !== null) {
-			message = messageBeforeVisit
-			messageBeforeVisit = null
-		}
-	}
-
 	let htmlPreview = $derived(micromark(message))
 
 	function insertMarkdown(before: string, after: string = '') {
@@ -206,8 +178,7 @@ ${userPostcode.toUpperCase()}`)
 					senderPostcode: userPostcode,
 					recipient: mp.email,
 					subject: subject.trim(),
-					message: message.trim(),
-					attendingVisit
+					message: message.trim()
 				})
 			})
 
@@ -266,23 +237,6 @@ ${userPostcode.toUpperCase()}`)
 					rows="1"
 					class="subject-textarea"
 				></textarea>
-			</div>
-
-			<div class="form-group visit-group">
-				<label class="visit-label" class:checked={attendingVisit}>
-					<input
-						type="checkbox"
-						class="visit-tickbox"
-						bind:checked={attendingVisit}
-						onchange={toggleVisit}
-					/>
-					<span class="visit-text">
-						I will attend PauseAI UK's
-						<Link href="https://luma.com/q2wu0y59?utm_source=uk-email-builder" target="_blank"
-							>visit to Parliament on 23<sup>rd</sup> June</Link
-						> to speak with my MP in person.
-					</span>
-				</label>
 			</div>
 
 			<div class="form-group">
@@ -509,76 +463,6 @@ ${userPostcode.toUpperCase()}`)
 		overflow: hidden;
 		white-space: pre-wrap;
 		word-wrap: break-word;
-	}
-
-	.visit-group {
-		padding-top: 1.5rem;
-	}
-
-	.visit-label {
-		display: flex;
-		align-items: flex-start;
-		gap: 0.7rem;
-		cursor: pointer;
-		padding: 0.85rem 1rem;
-		background: var(--bg);
-		border: 1px solid color-mix(in srgb, var(--brand) 28%, transparent);
-		border-radius: 8px;
-		font-weight: 400;
-		font-size: 0.95rem;
-		line-height: 1.45;
-		transition:
-			border-color 0.15s ease,
-			background-color 0.15s ease;
-	}
-
-	.visit-label:hover {
-		border-color: var(--brand);
-	}
-
-	.visit-label.checked {
-		border-color: var(--brand);
-		background: color-mix(in srgb, var(--brand) 10%, var(--bg));
-	}
-
-	.visit-tickbox {
-		appearance: none;
-		width: 1.15rem;
-		height: 1.15rem;
-		padding: 0;
-		margin: 0;
-		margin-top: 0.18rem;
-		flex-shrink: 0;
-		border: 2px solid var(--brand);
-		border-radius: 4px;
-		background: var(--bg);
-		cursor: pointer;
-		display: grid;
-		place-content: center;
-	}
-
-	.visit-tickbox::before {
-		content: '';
-		width: 0.65rem;
-		height: 0.65rem;
-		transform: scale(0);
-		transition: transform 0.1s ease-in-out;
-		background: var(--brand);
-		clip-path: polygon(14% 44%, 0 65%, 50% 100%, 100% 16%, 80% 0%, 43% 62%);
-	}
-
-	.visit-tickbox:checked::before {
-		transform: scale(1);
-	}
-
-	.visit-tickbox:focus-visible {
-		outline: 2px solid var(--brand);
-		outline-offset: 2px;
-	}
-
-	.visit-text {
-		flex: 1;
-		min-width: 0;
 	}
 
 	.email-tips {

--- a/src/routes/api/uk-send-mp-email/+server.ts
+++ b/src/routes/api/uk-send-mp-email/+server.ts
@@ -39,7 +39,6 @@ interface EmailRequest {
 	recipient: string
 	subject: string
 	message: string
-	attendingVisit?: boolean
 }
 
 type UKSendMPEmailApiSuccessResponse = {
@@ -164,8 +163,7 @@ export const POST: RequestHandler = async ({ request }) => {
 				Recipient: [mpRecordId], // Array of record IDs for linked field
 				Subject: data.subject,
 				Message: data.message,
-				Campaign: 'Frontier AI letter',
-				'Attending Parliament 23 June 2026': data.attendingVisit ?? false
+				Campaign: 'Frontier AI letter'
 			}
 		}
 


### PR DESCRIPTION
The June 23rd Parliament visit has passed, so this removes the opt-in "I will attend PauseAI UK's visit to Parliament" checkbox and all of its plumbing from the UK MP email builder:

- The checkbox UI, its state (`attendingVisit` / `messageBeforeVisit`), the `toggleVisit` logic, and the visit-sentence / next-steps constants.
- The visit-specific CSS.
- The `attendingVisit` field in the send payload, plus the server-side field on `EmailRequest` and its `Attending Parliament 23 June 2026` Airtable write.

The rest of the form (subject, message, attachments, confirm-before-send) is unchanged. Removing a field from the Airtable write is safe; the column itself is left in place.

Verified locally: `/uk-email-mp` and `/embed/uk-email-mp` both render with no compile errors.