### PR TITLE
Fix: write Discovery method as string, not array, to singleSelect Airtable field

### DIFF
--- a/src/lib/airtable.ts
+++ b/src/lib/airtable.ts
@@ -83,6 +83,31 @@ export async function fetchAllPages<T extends Record<string, unknown>>(
 }
 
 /**
+ * Finds the first record in a table where the Email field matches.
+ * Returns the record id, or undefined if not found or on error.
+ */
+export async function findRecordByEmail(
+	baseId: string,
+	tableId: string,
+	email: string
+): Promise<string | undefined> {
+	const apiKey = getWriteApiKey()
+	if (!apiKey) return undefined
+
+	try {
+		const base = new Airtable({ apiKey }).base(baseId)
+		const table = base(tableId)
+		const records = await table
+			.select({ filterByFormula: `{Email} = "${email}"`, maxRecords: 1, fields: ['Email'] })
+			.all()
+		return records[0]?.id
+	} catch (error) {
+		await reportError(error, { tableId, operation: 'findRecordByEmail' })
+		return undefined
+	}
+}
+
+/**
  * Creates a record in Airtable
  * @param baseId The Airtable Base ID
  * @param tableId The Airtable Table ID

--- a/src/lib/airtable.ts
+++ b/src/lib/airtable.ts
@@ -84,13 +84,13 @@ export async function fetchAllPages<T extends Record<string, unknown>>(
 
 /**
  * Finds the first record in a table where the Email field matches.
- * Returns the record id, or undefined if not found or on error.
+ * Returns the record id and Intent field, or undefined if not found or on error.
  */
 export async function findRecordByEmail(
 	baseId: string,
 	tableId: string,
 	email: string
-): Promise<string | undefined> {
+): Promise<{ id: string; intent: string } | undefined> {
 	const apiKey = getWriteApiKey()
 	if (!apiKey) return undefined
 
@@ -98,9 +98,15 @@ export async function findRecordByEmail(
 		const base = new Airtable({ apiKey }).base(baseId)
 		const table = base(tableId)
 		const records = await table
-			.select({ filterByFormula: `{Email} = "${email}"`, maxRecords: 1, fields: ['Email'] })
+			.select({
+				filterByFormula: `{Email} = "${email}"`,
+				maxRecords: 1,
+				fields: ['Email', 'Intent']
+			})
 			.all()
-		return records[0]?.id
+		const record = records[0]
+		if (!record) return undefined
+		return { id: record.id, intent: String(record.fields['Intent'] ?? '') }
 	} catch (error) {
 		await reportError(error, { tableId, operation: 'findRecordByEmail' })
 		return undefined

--- a/src/routes/embed/onboarding-form/+page.server.ts
+++ b/src/routes/embed/onboarding-form/+page.server.ts
@@ -6,7 +6,7 @@ import { fail } from '@sveltejs/kit'
 import type { FieldSet } from 'airtable'
 import type { Actions } from './$types'
 import type { NationalGroupsApiResponse } from '$api/national-groups/+server.js'
-import { createRecord, updateRecord } from '$lib/airtable'
+import { createRecord, findRecordByEmail, updateRecord } from '$lib/airtable'
 import { isOnboardingLive } from '$lib/server/onboarding'
 import { recordStubSubmission } from '$lib/server/onboarding-stub'
 import { subscribeToSubstackNewsletter } from '$lib/server/substack'
@@ -180,11 +180,24 @@ export const actions: Actions = {
 					return fail(502, { message: 'Sorry, we could not save your details. Please try again.' })
 				}
 			} else {
-				recordId = await createRecord(AIRTABLE_BASE_ID, MEMBERS_TABLE_ID, fields)
-				// A failed write returns undefined; surface it instead of telling
-				// the user they're signed up when no record was created.
-				if (!recordId) {
-					return fail(502, { message: 'Sorry, we could not save your details. Please try again.' })
+				// Upsert by email: if a record already exists (e.g. user retried
+				// after a network error), update it rather than creating a duplicate.
+				const existingByEmail = await findRecordByEmail(AIRTABLE_BASE_ID, MEMBERS_TABLE_ID, email)
+				if (existingByEmail) {
+					recordId = existingByEmail
+					const updated = await updateRecord(AIRTABLE_BASE_ID, MEMBERS_TABLE_ID, recordId, fields)
+					if (!updated) {
+						return fail(502, {
+							message: 'Sorry, we could not save your details. Please try again.'
+						})
+					}
+				} else {
+					recordId = await createRecord(AIRTABLE_BASE_ID, MEMBERS_TABLE_ID, fields)
+					if (!recordId) {
+						return fail(502, {
+							message: 'Sorry, we could not save your details. Please try again.'
+						})
+					}
 				}
 				// Subscription happens on the initial (step 2) submission only;
 				// the volunteer-form update never re-subscribes.

--- a/src/routes/embed/onboarding-form/+page.server.ts
+++ b/src/routes/embed/onboarding-form/+page.server.ts
@@ -151,11 +151,8 @@ export const actions: Actions = {
 			fields['Phone'] = getString(data, 'phone')
 			fields['Languages'] = languages
 			fields['Other languages'] = getString(data, 'languages_other')
-			// The post-cleanup Discovery field is a multipleSelects (legacy comma
-			// combos restored losslessly); the form asks single-choice, so write
-			// a one-element array.
 			if (discovery) {
-				fields['Discovery method of PAI'] = [discovery]
+				fields['Discovery method of PAI'] = discovery
 			}
 			fields['Discovery method of PAI (Other)'] = getString(data, 'discovery_specify')
 			fields['Motivation'] = motivations

--- a/src/routes/embed/onboarding-form/+page.server.ts
+++ b/src/routes/embed/onboarding-form/+page.server.ts
@@ -180,11 +180,12 @@ export const actions: Actions = {
 					return fail(502, { message: 'Sorry, we could not save your details. Please try again.' })
 				}
 			} else {
-				// Upsert by email: if a record already exists (e.g. user retried
-				// after a network error), update it rather than creating a duplicate.
+				// Upsert by email only when intent matches: prevents duplicates from
+				// retries, but lets someone sign up under a different intent (e.g.
+				// volunteer then act-now) without overwriting their existing record.
 				const existingByEmail = await findRecordByEmail(AIRTABLE_BASE_ID, MEMBERS_TABLE_ID, email)
-				if (existingByEmail) {
-					recordId = existingByEmail
+				if (existingByEmail && existingByEmail.intent === intent) {
+					recordId = existingByEmail.id
 					const updated = await updateRecord(AIRTABLE_BASE_ID, MEMBERS_TABLE_ID, recordId, fields)
 					if (!updated) {
 						return fail(502, {


### PR DESCRIPTION
## Summary

- **Fix Discovery field 422 error**: `Discovery method of PAI` is a `singleSelect` field in Airtable but code was writing an array — causing `INVALID_VALUE_FOR_COLUMN` 422 errors on every volunteer form submission
- **Prevent duplicate member records**: addresses #972 step-2 submissions now upsert by email+intent instead of blind-creating, so retries update the existing record rather than creating a second one. Step 2 is the right point to check — by then we have both email (carried from step 1) and intent, so the match is unambiguous. A different intent (e.g. someone who already signed up as a volunteer now submitting as act-now) still creates a new record rather than overwriting.

## Test plan

- [ ] Submit onboarding form with a discovery method selected — verify no 422 in Sentry
- [ ] Verify `Discovery method of PAI` field populated correctly in Airtable Members table
- [ ] Submit step 2 twice with the same email and intent — verify only one Airtable record exists after second submission
- [ ] Submit step 2 with an email that already has a Volunteer record but a different intent — verify a new record is created, not an overwrite

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HYSJGpmpKvh2dKDsM8Q88X