### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/scheduled-build.yml
+++ b/.github/workflows/scheduled-build.yml
@@ -8,6 +8,8 @@ on:
 #   workflow_dispatch:
 #     # Allow manual triggering
 
+permissions: {}
+
 jobs:
   rebuild:
     name: Trigger Netlify Build


### PR DESCRIPTION
Potential fix for [https://github.com/PauseAI/pauseai-website/security/code-scanning/1](https://github.com/PauseAI/pauseai-website/security/code-scanning/1)

Add an explicit `permissions` block to `.github/workflows/scheduled-build.yml` at the workflow root, immediately after the `on:` section (or near the top before `jobs:`), to ensure all jobs in this workflow receive least-privilege token scopes by default.  
For this workflow, the safest minimal setting is:

- `permissions: {}`

This disables all `GITHUB_TOKEN` permissions, which is valid here because the job only uses a secret and `curl` to call an external URL and does not need GitHub API/repo writes. This change preserves functionality while satisfying CodeQL.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
