### PR TITLE
Potential fix for code scanning alert no. 13: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pnpm-check.yml
+++ b/.github/workflows/pnpm-check.yml
@@ -6,6 +6,9 @@ on:
       - main
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   pnpm-check:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/PauseAI/pauseai-website/security/code-scanning/13](https://github.com/PauseAI/pauseai-website/security/code-scanning/13)

Add an explicit `permissions` block at the workflow root so all jobs inherit least-privilege defaults unless overridden. For this CI workflow, the minimal required scope is `contents: read` (needed for checkout/repo read operations). This preserves current behavior while preventing unintended token write capabilities.

Edit only `.github/workflows/pnpm-check.yml` and insert:

```yml
permissions:
  contents: read
```

immediately after the `on:` trigger section (before `jobs:`), or near the top-level keys. No imports/methods/dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
