### PR TITLE
Add paying member opt-in to volunteer onboarding step

### DIFF
--- a/docs/ONBOARDING_EMBED.md
+++ b/docs/ONBOARDING_EMBED.md
@@ -44,7 +44,7 @@ Example — a French-speaking regional chapter embed:
 
 Country/city/languages are things a chapter can reasonably know in advance about its audience — who's filling the form out, they can't. Personal fields (name, email, phone, intent, discovery source, etc.) are intentionally **not** prefillable via URL:
 
-- Consent checkboxes (GDPR, volunteer agreement, code of conduct, newsletter/keep-informed opt-ins) must be actively given by the visitor — prefilling them via a shareable URL would be a dark pattern.
+- Consent checkboxes (GDPR, volunteer agreement, code of conduct, newsletter/keep-informed opt-ins) must be actively given by the visitor — prefilling them via a shareable URL would be a dark pattern. The volunteer step's "become a paying member" opt-in is also not prefillable today, though this is less deliberate than the consent-box exclusion.
 - Contact details (name, email, phone, Discord username) have no legitimate source when the same embed link is shared broadly to an unknown audience.
 
 ## Mode: stub vs. live

--- a/docs/join-form-flow.md
+++ b/docs/join-form-flow.md
@@ -98,7 +98,7 @@ duplicate.
 
 - `step` (`1 → 4`), `mode` (`'contact' | 'browse'`), `intent`
   (`'act-now' | 'volunteer' | 'lead' | null`), and the `basics` / `volunteer` /
-  `agreements` / `gdprConsent` state objects.
+  `agreements` / `gdprConsent` / `becomePayingMember` state.
 - All form markup for steps 1–4, including the browse-mode inline signup and
   the lead-path `mailto:` hand-off (no submission).
 - A `submitWith(onSuccess)` helper that wraps SvelteKit's `enhance` to manage
@@ -169,9 +169,10 @@ stateDiagram-v2
     BrowseSignup: POST /embed/onboarding-form?/submit<br/>(mode=browse, intent=act-now)
     BrowseSignup --> Browse: success → inline confirmation
 
-    Step3Volunteer: Step 3 — Volunteer form<br/>(languages, skills, hours, agreements)
+    Step3Volunteer: Step 3 — Volunteer form<br/>(languages, skills, hours, agreements,<br/>optional paying-member opt-in)
     Step3Volunteer --> Step2: Back
     Step3Volunteer --> Submit3: Submit (POST, volunteer_details=on)
+    Submit3 --> Stripe: success + become_paying_member<br/>(opens Stripe in new tab)
     Submit3 --> Step4: success
 
     Step3Lead: Step 3 — Lead role description<br/>(mailto link to Organizing Director)
@@ -230,6 +231,26 @@ to the Organizing Director (Irina@pauseai.info). The country is checked against
 `/api/national-groups` to decide between "National Group Lead" (no existing
 chapter) and "Regional Group Lead" (chapter exists). No POST is made; the
 hand-off happens off-platform via email.
+
+## Paying member opt-in (volunteer step)
+
+The volunteer form (step 3) includes an optional "I want to become a paying
+member" checkbox (`become_paying_member`). It is **not** required, so it does
+not gate the submit button.
+
+When checked, the volunteer form's success handler opens the Stripe payment link
+in a new tab (`window.open(..., '_blank')`) with two query params, mirroring
+the legacy Tally form's `/submitted` contract:
+
+- `prefilled_email` — the volunteer's email from `basics.email`.
+- `client_reference_id` — the Airtable `recordId` returned by the submit
+  action (captured by `submitWith`), replacing Tally's submission id.
+
+The user stays in the onboarding flow: the form advances to the step-4
+volunteer confirmation regardless of whether the checkbox was checked. The
+`/submitted` route is **not** used by this path — it remains for the legacy
+Tally form only. The Stripe link constant lives in `OnboardingFlow.svelte`
+(`STRIPE_PAYMENT_LINK`) and matches the one in `src/routes/submitted/+page.svelte`.
 
 ## Related documents
 

--- a/docs/join-form-flow.md
+++ b/docs/join-form-flow.md
@@ -138,6 +138,8 @@ flowchart LR
     Action -- "ONBOARDING_LIVE != true" --> Stub["recordStubSubmission()<br/>/embed/onboarding-form/stub"]
     Action -- "newsletter + create" --> Substack["Substack subscription"]
     Action -- "{ success, recordId }" --> Flow
+    Flow -- "become_paying_member" --> Stripe["Stripe donation page<br/>(new tab)"]
+    Stripe -- "success URL" --> Close["/close<br/>(closes the tab)"]
 ```
 
 Both entry points converge on the same component and the same action, so
@@ -173,6 +175,8 @@ stateDiagram-v2
     Step3Volunteer --> Step2: Back
     Step3Volunteer --> Submit3: Submit (POST, volunteer_details=on)
     Submit3 --> Stripe: success + become_paying_member<br/>(opens Stripe in new tab)
+    Stripe --> Close: payment complete<br/>(Stripe success URL → /close)
+    Close: /close<br/>(closes the tab)
     Submit3 --> Step4: success
 
     Step3Lead: Step 3 — Lead role description<br/>(mailto link to Organizing Director)

--- a/docs/join-form-flow.md
+++ b/docs/join-form-flow.md
@@ -238,19 +238,28 @@ The volunteer form (step 3) includes an optional "I want to become a paying
 member" checkbox (`become_paying_member`). It is **not** required, so it does
 not gate the submit button.
 
-When checked, the volunteer form's success handler opens the Stripe payment link
-in a new tab (`window.open(..., '_blank')`) with two query params, mirroring
-the legacy Tally form's `/submitted` contract:
+When checked, the volunteer form opens the Stripe payment link in a new tab
+with two query params, mirroring the legacy Tally form's `/submitted` contract:
 
-- `prefilled_email` — the volunteer's email from `basics.email`.
-- `client_reference_id` — the Airtable `recordId` returned by the submit
-  action (captured by `submitWith`), replacing Tally's submission id.
+- `prefilled_email` — the volunteer's email.
+- `client_reference_id` — the Airtable record id, replacing Tally's submission id.
+
+The popup is opened synchronously during the submit gesture (so iOS Safari
+and Chrome on iOS allow it), then navigated to the final Stripe URL once the
+record has been saved.
 
 The user stays in the onboarding flow: the form advances to the step-4
 volunteer confirmation regardless of whether the checkbox was checked. The
 `/submitted` route is **not** used by this path — it remains for the legacy
-Tally form only. The Stripe link constant lives in `OnboardingFlow.svelte`
-(`STRIPE_PAYMENT_LINK`) and matches the one in `src/routes/submitted/+page.svelte`.
+Tally form only.
+
+### Stripe success redirect (`/close`)
+
+After completing payment, Stripe redirects the popup to [`/close`](../src/routes/close/+page.svelte),
+which closes the tab automatically. If the browser blocks the close (e.g. the
+user navigated manually), a brief "Thanks for your donation!" message is
+shown as a fallback. The Stripe success URL must be configured to
+`https://pauseai.info/close`.
 
 ## Related documents
 

--- a/src/lib/components/onboarding/OnboardingFlow.svelte
+++ b/src/lib/components/onboarding/OnboardingFlow.svelte
@@ -849,9 +849,14 @@
 					<!-- eslint-disable-next-line svelte/no-at-html-tags -->
 					<span>{@html msgs.onboarding_become_paying_member}</span>
 				</label>
-				<button type="submit" class="primary" disabled={!volunteerFormComplete || submitting}>
-					{submitting ? msgs.onboarding_btn_submitting : msgs.onboarding_btn_submit}
-				</button>
+				<div class="submit-group">
+					<button type="submit" class="primary" disabled={!volunteerFormComplete || submitting}>
+						{submitting ? msgs.onboarding_btn_submitting : msgs.onboarding_btn_submit}
+					</button>
+					{#if becomePayingMember}
+						<p class="submit-disclaimer">{msgs.onboarding_become_paying_member_disclaimer}</p>
+					{/if}
+				</div>
 				<button type="button" class="back" onclick={() => (step = 2)}
 					>{msgs.onboarding_btn_back}</button
 				>
@@ -1085,6 +1090,19 @@
 	button.back:hover {
 		opacity: 1;
 		text-decoration: underline;
+	}
+
+	.submit-group {
+		display: flex;
+		flex-direction: column;
+		align-items: stretch;
+	}
+
+	.submit-disclaimer {
+		margin: 0.5rem 0 0;
+		text-align: center;
+		font-size: 0.85rem;
+		opacity: 0.7;
 	}
 
 	.intent-grid {

--- a/src/lib/components/onboarding/OnboardingFlow.svelte
+++ b/src/lib/components/onboarding/OnboardingFlow.svelte
@@ -129,6 +129,17 @@
 
 	let agreements = $state({ volunteer: false, conduct: false })
 
+	// Stripe payment link used when a volunteer opts in to becoming a paying
+	// member on the volunteer step. Same link as /submitted uses.
+	const STRIPE_PAYMENT_LINK = 'https://donate.stripe.com/6oU14n1RD0So1oGftCd7q01'
+
+	// Volunteer step: optional opt-in to become a paying member. When checked,
+	// the success handler opens Stripe in a new tab (prefilled with the email
+	// and the Airtable record id as client_reference_id, mirroring the legacy
+	// Tally form's query params) and advances to the confirmation step so the
+	// user stays in the flow.
+	let becomePayingMember = $state(false)
+
 	// GDPR data-processing consent gating every record-creating submission
 	// (step 2 + browse). Chapter-sharing consent is not bundled here: it lives
 	// in the optional "Keep me informed" opt-in, since we only share details
@@ -636,7 +647,16 @@
 			<form
 				method="POST"
 				action="/embed/onboarding-form?/submit"
-				use:enhance={submitWith(() => (step = 4))}
+				use:enhance={submitWith(() => {
+					if (becomePayingMember) {
+						const params = new URLSearchParams({
+							prefilled_email: basics.email,
+							client_reference_id: recordId
+						})
+						window.open(`${STRIPE_PAYMENT_LINK}?${params.toString()}`, '_blank')
+					}
+					step = 4
+				})}
 			>
 				{@render honeypotField('ob-nickname-4')}
 				<input type="hidden" name="mode" value="contact" />
@@ -804,6 +824,12 @@
 					<span class="checkbox-box" aria-hidden="true"></span>
 					<!-- eslint-disable-next-line svelte/no-at-html-tags -->
 					<span>{@html msgs.onboarding_agree_conduct}</span>
+				</label>
+				<label class="agreement">
+					<input type="checkbox" name="become_paying_member" bind:checked={becomePayingMember} />
+					<span class="checkbox-box" aria-hidden="true"></span>
+					<!-- eslint-disable-next-line svelte/no-at-html-tags -->
+					<span>{@html msgs.onboarding_become_paying_member}</span>
 				</label>
 				<button type="submit" class="primary" disabled={!volunteerFormComplete || submitting}>
 					{submitting ? msgs.onboarding_btn_submitting : msgs.onboarding_btn_submit}

--- a/src/lib/components/onboarding/OnboardingFlow.svelte
+++ b/src/lib/components/onboarding/OnboardingFlow.svelte
@@ -243,9 +243,18 @@
 		step = 2
 	}
 
-	function submitWith(onSuccess: (data?: Record<string, unknown>) => void): SubmitFunction {
+	function submitWith<T>(
+		onStart: () => T,
+		onSuccess: (data: Record<string, unknown> | undefined, startValue: T) => void
+	): SubmitFunction {
 		return () => {
 			submitting = true
+			// Run the start callback synchronously, inside the user gesture,
+			// so callers can do things that require a gesture (e.g. opening a
+			// popup window before an async fetch resolves). The returned value
+			// is passed to onSuccess so it can act on it (e.g. navigate the
+			// already-opened popup to its final URL once the record id is known).
+			const startValue = onStart()
 			return ({ result }) => {
 				submitting = false
 				if (result.type === 'success') {
@@ -254,7 +263,7 @@
 					if (typeof result.data?.recordId === 'string') {
 						recordId = result.data.recordId
 					}
-					onSuccess(result.data)
+					onSuccess(result.data, startValue)
 				} else if (result.type === 'failure') {
 					toast.error(String(result.data?.message ?? msgs.onboarding_error_generic))
 				} else {
@@ -449,7 +458,10 @@
 			<form
 				method="POST"
 				action="/embed/onboarding-form?/submit"
-				use:enhance={submitWith(() => (step = 3))}
+				use:enhance={submitWith(
+					() => {},
+					() => (step = 3)
+				)}
 			>
 				{@render hiddenBasics()}
 				{@render honeypotField('ob-nickname-2')}
@@ -580,7 +592,10 @@
 						<form
 							method="POST"
 							action="/embed/onboarding-form?/submit"
-							use:enhance={submitWith(() => (browseSignedUp = true))}
+							use:enhance={submitWith(
+								() => {},
+								() => (browseSignedUp = true)
+							)}
 						>
 							{@render honeypotField('ob-nickname-3')}
 							<input type="hidden" name="mode" value="browse" />
@@ -647,16 +662,19 @@
 			<form
 				method="POST"
 				action="/embed/onboarding-form?/submit"
-				use:enhance={submitWith(() => {
-					if (becomePayingMember) {
-						const params = new URLSearchParams({
-							prefilled_email: basics.email,
-							client_reference_id: recordId
-						})
-						window.open(`${STRIPE_PAYMENT_LINK}?${params.toString()}`, '_blank')
+				use:enhance={submitWith(
+					() => (becomePayingMember ? window.open('', '_blank') : null),
+					(_, popup) => {
+						if (becomePayingMember && popup) {
+							const params = new URLSearchParams({
+								prefilled_email: basics.email,
+								client_reference_id: recordId
+							})
+							popup.location.href = `${STRIPE_PAYMENT_LINK}?${params.toString()}`
+						}
+						step = 4
 					}
-					step = 4
-				})}
+				)}
 			>
 				{@render honeypotField('ob-nickname-4')}
 				<input type="hidden" name="mode" value="contact" />

--- a/src/lib/components/onboarding/messages.ts
+++ b/src/lib/components/onboarding/messages.ts
@@ -82,6 +82,7 @@ export interface OnboardingMessages {
 	onboarding_agree_volunteer: string
 	onboarding_agree_conduct: string
 	onboarding_become_paying_member: string
+	onboarding_become_paying_member_disclaimer: string
 	onboarding_lead_title: (role: string) => string
 	onboarding_lead_meta: string
 	onboarding_lead_intro: string
@@ -269,6 +270,8 @@ const en: OnboardingMessages = {
 		'I agree with the <a target="_blank" rel="noopener noreferrer" href="/code-of-conduct">Code of Conduct</a>&nbsp;*',
 	onboarding_become_paying_member:
 		'I want to become a paying member — open the donation page after submitting.',
+	onboarding_become_paying_member_disclaimer:
+		'The payment processor (Stripe) will open in a new tab when you submit.',
 	onboarding_lead_title: (role) => `${role} Volunteer Description`,
 	onboarding_lead_meta: 'Part-time volunteer role · 5–15 hours/week',
 	onboarding_lead_intro:
@@ -478,6 +481,8 @@ const de: OnboardingMessages = {
 		'Ich stimme dem <a target="_blank" rel="noopener noreferrer" href="/code-of-conduct">Verhaltenskodex</a> zu&nbsp;*',
 	onboarding_become_paying_member:
 		'Ich möchte zahlendes Mitglied werden — nach dem Absenden die Spendenseite öffnen.',
+	onboarding_become_paying_member_disclaimer:
+		'Der Zahlungsanbieter (Stripe) wird beim Absenden in einem neuen Tab geöffnet.',
 	onboarding_lead_title: (role) => `${role} – Freiwilligenbeschreibung`,
 	onboarding_lead_meta: 'Ehrenamtliche Teilzeitrolle · 5–15 Stunden/Woche',
 	onboarding_lead_intro:

--- a/src/lib/components/onboarding/messages.ts
+++ b/src/lib/components/onboarding/messages.ts
@@ -81,6 +81,7 @@ export interface OnboardingMessages {
 	onboarding_placeholder_specify: string
 	onboarding_agree_volunteer: string
 	onboarding_agree_conduct: string
+	onboarding_become_paying_member: string
 	onboarding_lead_title: (role: string) => string
 	onboarding_lead_meta: string
 	onboarding_lead_intro: string
@@ -266,6 +267,8 @@ const en: OnboardingMessages = {
 		'I agree with the <a target="_blank" rel="noopener noreferrer" href="/volunteer-agreement">Volunteer Agreement</a>&nbsp;*',
 	onboarding_agree_conduct:
 		'I agree with the <a target="_blank" rel="noopener noreferrer" href="/code-of-conduct">Code of Conduct</a>&nbsp;*',
+	onboarding_become_paying_member:
+		'I want to become a paying member — open the donation page after submitting.',
 	onboarding_lead_title: (role) => `${role} Volunteer Description`,
 	onboarding_lead_meta: 'Part-time volunteer role · 5–15 hours/week',
 	onboarding_lead_intro:
@@ -473,6 +476,8 @@ const de: OnboardingMessages = {
 		'Ich stimme der <a target="_blank" rel="noopener noreferrer" href="/volunteer-agreement">Freiwilligenvereinbarung</a> zu&nbsp;*',
 	onboarding_agree_conduct:
 		'Ich stimme dem <a target="_blank" rel="noopener noreferrer" href="/code-of-conduct">Verhaltenskodex</a> zu&nbsp;*',
+	onboarding_become_paying_member:
+		'Ich möchte zahlendes Mitglied werden — nach dem Absenden die Spendenseite öffnen.',
 	onboarding_lead_title: (role) => `${role} – Freiwilligenbeschreibung`,
 	onboarding_lead_meta: 'Ehrenamtliche Teilzeitrolle · 5–15 Stunden/Woche',
 	onboarding_lead_intro:

--- a/src/routes/close/+page.svelte
+++ b/src/routes/close/+page.svelte
@@ -1,0 +1,23 @@
+<!--
+	/close — Stripe success redirect target.
+
+	When a volunteer opts in to becoming a paying member, the onboarding flow
+	opens Stripe in a new tab via `window.open()`. Stripe's success URL is
+	configured to redirect here. Because the tab was script-opened, `window.close()`
+	can close it automatically. If the user navigated here manually (or the
+	browser blocks the close), a fallback message is shown.
+-->
+<script lang="ts">
+	import { onMount } from 'svelte'
+
+	onMount(() => {
+		window.close()
+	})
+</script>
+
+<svelte:head>
+	<title>Done — PauseAI</title>
+</svelte:head>
+
+<h1>✓ Thanks for your donation!</h1>
+<p>You can close this tab now.</p>


### PR DESCRIPTION
## Summary

Adds an optional "I want to become a paying member" checkbox to the volunteer step (step 3) of the onboarding flow. When checked, submitting the volunteer form opens the Stripe donation page in a new tab and the user advances to the volunteer confirmation step (step 4) as usual, staying within the flow. After completing payment, Stripe redirects the popup to a new `/close` route that closes the tab automatically (with a fallback message if the browser blocks the close).

## Context

This opt-in existed in the legacy Tally volunteer form (which redirected to `/submitted` → Stripe with `prefilled_email` and `client_reference_id` params) but was lost when the onboarding flow was migrated to the custom `OnboardingFlow.svelte` component. Adding it back was approved on Discord.

## Changes

- **`src/lib/components/onboarding/OnboardingFlow.svelte`**
  - Added a `becomePayingMember` state flag and a `STRIPE_PAYMENT_LINK` constant (same link as `/submitted` uses).
  - Added an optional checkbox to the volunteer form, after the Code of Conduct agreement. It is **not** required, so it doesn't gate the submit button.
  - Extended `submitWith` to take `(onStart, onSuccess)`: `onStart` runs synchronously during the user's submit gesture and its return value is passed to `onSuccess`. This lets callers do gesture-gated work (like opening a popup) before the async fetch resolves.
  - The volunteer form's `onStart` opens a blank popup synchronously (`window.open('', '_blank')`) during the gesture — satisfying iOS Safari and Chrome on iOS, which only allow `window.open` during a user gesture. `onSuccess` then navigates the already-opened popup to the final Stripe URL (with `prefilled_email` from `basics.email` and `client_reference_id` from the Airtable `recordId` captured by `submitWith`, replacing Tally's submission id), and advances to step 4 regardless.
  - The two existing `submitWith` call sites were updated to the new signature with a no-op `onStart`.
  - The `/submitted` route is left untouched — it remains for the legacy Tally form only.
- **`src/routes/close/+page.svelte`** (new) — Stripe success redirect target. Calls `window.close()` on mount; because the tab was script-opened by `window.open()`, the browser permits it to close itself. If the user navigated here manually (or the browser blocks the close), a fallback "✓ Thanks for your donation! / You can close this tab now." message is shown. The Stripe success URL must be configured to `https://pauseai.info/close`.
- **`src/lib/components/onboarding/messages.ts`** — added the `onboarding_become_paying_member` message to the `OnboardingMessages` interface and both the `en` and `de` locales.
- **`docs/join-form-flow.md`** — documented the new `becomePayingMember` state, updated the step-machine state diagram and submission flowchart to include the `Stripe → /close` path, and added a "Paying member opt-in (volunteer step)" section plus a "Stripe success redirect (`/close`)" section explaining the auto-close behavior and the required Stripe success URL.
- **`docs/ONBOARDING_EMBED.md`** — noted the opt-in is not prefillable via embed URL.

## TODO

- [ ] ~~**iOS popup navigation:** Opening the popup synchronously during the submit gesture works (no confirmation prompt), but navigating the already-opened popup to the final Stripe URL after the async submission resolves does **not** work under iOS Safari / Chrome on iOS. Needs an alternative approach (e.g. render a Stripe link on the confirmation step that the user taps directly, or pre-build the URL before opening the popup).~~ Resolved: This was a false alarm.
- [x] Configure Stripe for the new setup — the Stripe tab now closes automatically when payment is done, via the new `/close` success-redirect route. **Action required:** set the Stripe payment link's success URL to `https://pauseai.info/close`.
- [x] Update [PauseAI/pauseai-automation](https://github.com/PauseAI/pauseai-automation) to accept Airtable record ID as customer reference instead of Tally submission ID.

## How to test

1. Go to `/join` (or `/embed/onboarding-form`).
2. Complete step 1 (basic info) and step 2 (pick "I want to volunteer regularly").
3. On the volunteer step, fill in the required fields and check "I want to become a paying member".
4. Submit — a new tab should open to the Stripe donation page with the email prefilled, and the form should advance to the volunteer confirmation screen.
5. Submit again without the checkbox — should advance to the confirmation screen with no new tab.
6. (Stripe success redirect) Complete a test payment in the Stripe tab. Stripe should redirect to `/close`, which auto-closes the tab. To test the fallback, navigate to `/close` directly in a non-script-opened tab — you should see "✓ Thanks for your donation!" instead of the tab closing.