### PR TITLE
Remove Gmail hint from email field

### DIFF
--- a/src/lib/components/onboarding/OnboardingFlow.svelte
+++ b/src/lib/components/onboarding/OnboardingFlow.svelte
@@ -422,7 +422,6 @@
 						autocomplete="email"
 						bind:value={basics.email}
 					/>
-					<p class="helper">{msgs.onboarding_helper_email_gmail}</p>
 					<!-- <p class="helper">
 						We may contact you about critical mobilizations, see our
 						<Link href="/privacy">privacy policy</Link>.

--- a/src/lib/components/onboarding/messages.ts
+++ b/src/lib/components/onboarding/messages.ts
@@ -11,7 +11,6 @@ export interface OnboardingMessages {
 	onboarding_placeholder_full_name: string
 	onboarding_field_email: string
 	onboarding_placeholder_email: string
-	onboarding_helper_email_gmail: string
 	onboarding_field_country: string
 	onboarding_placeholder_country: string
 	onboarding_field_city: string
@@ -189,7 +188,6 @@ const en: OnboardingMessages = {
 	onboarding_placeholder_full_name: 'Full name',
 	onboarding_field_email: 'Email *',
 	onboarding_placeholder_email: 'Email',
-	onboarding_helper_email_gmail: 'Preferably Gmail if you have one.',
 	onboarding_field_country: 'Country of residence *',
 	onboarding_placeholder_country: 'Select your country',
 	onboarding_field_city: 'City / town of residence *',
@@ -400,7 +398,6 @@ const de: OnboardingMessages = {
 	onboarding_placeholder_full_name: 'Vollständiger Name',
 	onboarding_field_email: 'E-Mail *',
 	onboarding_placeholder_email: 'E-Mail',
-	onboarding_helper_email_gmail: 'Falls vorhanden, bevorzugt Gmail.',
 	onboarding_field_country: 'Wohnsitzland *',
 	onboarding_placeholder_country: 'Land auswählen',
 	onboarding_field_city: 'Stadt / Gemeinde *',
@@ -621,7 +618,6 @@ const fr: OnboardingMessages = {
 	onboarding_placeholder_full_name: 'Nom complet',
 	onboarding_field_email: 'E-mail *',
 	onboarding_placeholder_email: 'E-mail',
-	onboarding_helper_email_gmail: 'De préférence Gmail si tu en as un.',
 	onboarding_field_country: 'Pays de résidence *',
 	onboarding_placeholder_country: 'Sélectionne ton pays',
 	onboarding_field_city: 'Ville / commune de résidence *',


### PR DESCRIPTION
## Summary
- Removes the "Preferably Gmail if you have one." helper text from the email field
- Deletes the `onboarding_helper_email_gmail` key from type definition, all three locales (en/de/fr), and the Svelte template

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R3kGVuVEmKN68CUu8Gmr9M