### PR TITLE
Show the critical-alert notice on the signup form

### DIFF
--- a/src/lib/components/onboarding/OnboardingFlow.svelte
+++ b/src/lib/components/onboarding/OnboardingFlow.svelte
@@ -422,10 +422,8 @@
 						autocomplete="email"
 						bind:value={basics.email}
 					/>
-					<!-- <p class="helper">
-						We may contact you about critical mobilizations, see our
-						<Link href="/privacy">privacy policy</Link>.
-					</p> -->
+					<!-- eslint-disable-next-line svelte/no-at-html-tags -->
+					<p class="helper">{@html msgs.onboarding_email_critical_notice}</p>
 				</div>
 				<div class="field">
 					<label class="field-label" for="ob-country">{msgs.onboarding_field_country}</label>
@@ -621,10 +619,8 @@
 									autocomplete="email"
 									bind:value={basics.email}
 								/>
-								<!-- <p class="helper">
-									We may contact you about critical mobilizations, see our
-									<Link href="/privacy">privacy policy</Link>.
-								</p> -->
+								<!-- eslint-disable-next-line svelte/no-at-html-tags -->
+								<p class="helper">{@html msgs.onboarding_email_critical_notice}</p>
 							</div>
 							<div class="field">
 								<label class="field-label" for="loop-country">{msgs.onboarding_field_country}</label

--- a/src/lib/components/onboarding/OnboardingFlow.svelte
+++ b/src/lib/components/onboarding/OnboardingFlow.svelte
@@ -422,8 +422,6 @@
 						autocomplete="email"
 						bind:value={basics.email}
 					/>
-					<!-- eslint-disable-next-line svelte/no-at-html-tags -->
-					<p class="helper">{@html msgs.onboarding_email_critical_notice}</p>
 				</div>
 				<div class="field">
 					<label class="field-label" for="ob-country">{msgs.onboarding_field_country}</label>
@@ -515,6 +513,8 @@
 						</span>
 					</button>
 				</div>
+				<!-- eslint-disable-next-line svelte/no-at-html-tags -->
+				<p class="helper">{@html msgs.onboarding_email_critical_notice}</p>
 				<p class="section-label">{msgs.onboarding_intent_more_optional}</p>
 				<div class="intent-stack" role="radiogroup" aria-label="Want to do more?">
 					{#each intentOptions as option (option.key)}
@@ -619,8 +619,6 @@
 									autocomplete="email"
 									bind:value={basics.email}
 								/>
-								<!-- eslint-disable-next-line svelte/no-at-html-tags -->
-								<p class="helper">{@html msgs.onboarding_email_critical_notice}</p>
 							</div>
 							<div class="field">
 								<label class="field-label" for="loop-country">{msgs.onboarding_field_country}</label

--- a/src/lib/components/onboarding/OnboardingFlow.svelte
+++ b/src/lib/components/onboarding/OnboardingFlow.svelte
@@ -479,6 +479,7 @@
 						class="intent-option"
 						class:selected={keepInformed}
 						role="checkbox"
+						aria-describedby="critical-alert-notice"
 						aria-checked={keepInformed}
 						onclick={() => (keepInformed = !keepInformed)}
 					>
@@ -498,6 +499,7 @@
 						class="intent-option"
 						class:selected={basics.newsletter}
 						role="checkbox"
+						aria-describedby="critical-alert-notice"
 						aria-checked={basics.newsletter}
 						onclick={() => (basics.newsletter = !basics.newsletter)}
 					>
@@ -513,8 +515,10 @@
 						</span>
 					</button>
 				</div>
-				<!-- eslint-disable-next-line svelte/no-at-html-tags -->
-				<p class="helper">{@html msgs.onboarding_email_critical_notice}</p>
+				<p class="helper" id="critical-alert-notice">
+					<!-- eslint-disable-next-line svelte/no-at-html-tags -->
+					{@html msgs.onboarding_email_critical_notice}
+				</p>
 				<p class="section-label">{msgs.onboarding_intent_more_optional}</p>
 				<div class="intent-stack" role="radiogroup" aria-label="Want to do more?">
 					{#each intentOptions as option (option.key)}

--- a/src/lib/components/onboarding/messages.ts
+++ b/src/lib/components/onboarding/messages.ts
@@ -624,7 +624,7 @@ const fr: OnboardingMessages = {
 	onboarding_field_email: 'E-mail *',
 	onboarding_placeholder_email: 'E-mail',
 	onboarding_email_critical_notice:
-		'Nous pouvons occasionnellement vous envoyer une alerte critique, même si vous n\'en sélectionnez aucune. Voir notre <a target="_blank" rel="noopener noreferrer" href="/privacy">politique de confidentialité</a>.',
+		'Nous pouvons occasionnellement t\'envoyer une alerte urgente, même si tu ne sélectionnes aucune de ces options. Consulte notre <a target="_blank" rel="noopener noreferrer" href="/privacy">politique de confidentialité</a>.',
 	onboarding_field_country: 'Pays de résidence *',
 	onboarding_placeholder_country: 'Sélectionne ton pays',
 	onboarding_field_city: 'Ville / commune de résidence *',

--- a/src/lib/components/onboarding/messages.ts
+++ b/src/lib/components/onboarding/messages.ts
@@ -402,7 +402,7 @@ const de: OnboardingMessages = {
 	onboarding_field_email: 'E-Mail *',
 	onboarding_placeholder_email: 'E-Mail',
 	onboarding_email_critical_notice:
-		'Wir können dir gelegentlich eine kritische Warnung senden, auch wenn du nichts davon auswählst. Siehe unsere <a target="_blank" rel="noopener noreferrer" href="/privacy">Datenschutzrichtlinie</a>.',
+		'In dringenden Fällen könnten wir dir eine Nachricht senden, auch wenn du nichts davon auswählst. Siehe unsere <a target="_blank" rel="noopener noreferrer" href="/privacy">Datenschutzrichtlinie</a>.',
 	onboarding_field_country: 'Wohnsitzland *',
 	onboarding_placeholder_country: 'Land auswählen',
 	onboarding_field_city: 'Stadt / Gemeinde *',

--- a/src/lib/components/onboarding/messages.ts
+++ b/src/lib/components/onboarding/messages.ts
@@ -402,7 +402,7 @@ const de: OnboardingMessages = {
 	onboarding_field_email: 'E-Mail *',
 	onboarding_placeholder_email: 'E-Mail',
 	onboarding_email_critical_notice:
-		'Wir senden dir gelegentlich eine kritische Warnung, auch wenn du dich für nichts anderes anmeldest. Siehe unsere <a target="_blank" rel="noopener noreferrer" href="/privacy">Datenschutzrichtlinie</a>.',
+		'Wir können dir gelegentlich eine kritische Warnung senden, auch wenn du dich für nichts anderes anmeldest. Siehe unsere <a target="_blank" rel="noopener noreferrer" href="/privacy">Datenschutzrichtlinie</a>.',
 	onboarding_field_country: 'Wohnsitzland *',
 	onboarding_placeholder_country: 'Land auswählen',
 	onboarding_field_city: 'Stadt / Gemeinde *',

--- a/src/lib/components/onboarding/messages.ts
+++ b/src/lib/components/onboarding/messages.ts
@@ -402,7 +402,7 @@ const de: OnboardingMessages = {
 	onboarding_field_email: 'E-Mail *',
 	onboarding_placeholder_email: 'E-Mail',
 	onboarding_email_critical_notice:
-		'In dringenden Fällen könnten wir dir eine Nachricht senden, auch wenn du nichts davon auswählst. Siehe unsere <a target="_blank" rel="noopener noreferrer" href="/privacy">Datenschutzrichtlinie</a>.',
+		'In dringenden Fällen könnten wir dir eine Nachricht senden, auch wenn du keine dieser Optionen wählst. Siehe unsere <a target="_blank" rel="noopener noreferrer" href="/privacy">Datenschutzrichtlinie</a>.',
 	onboarding_field_country: 'Wohnsitzland *',
 	onboarding_placeholder_country: 'Land auswählen',
 	onboarding_field_city: 'Stadt / Gemeinde *',

--- a/src/lib/components/onboarding/messages.ts
+++ b/src/lib/components/onboarding/messages.ts
@@ -190,7 +190,7 @@ const en: OnboardingMessages = {
 	onboarding_field_email: 'Email *',
 	onboarding_placeholder_email: 'Email',
 	onboarding_email_critical_notice:
-		'We may occasionally send you a critical alert, even if you don\'t opt into anything else. See our <a target="_blank" rel="noopener noreferrer" href="/privacy">privacy policy</a>.',
+		'We may occasionally send you a critical alert, even if you don\'t opt into any of these. See our <a target="_blank" rel="noopener noreferrer" href="/privacy">privacy policy</a>.',
 	onboarding_field_country: 'Country of residence *',
 	onboarding_placeholder_country: 'Select your country',
 	onboarding_field_city: 'City / town of residence *',
@@ -402,7 +402,7 @@ const de: OnboardingMessages = {
 	onboarding_field_email: 'E-Mail *',
 	onboarding_placeholder_email: 'E-Mail',
 	onboarding_email_critical_notice:
-		'Wir können dir gelegentlich eine kritische Warnung senden, auch wenn du dich für nichts anderes anmeldest. Siehe unsere <a target="_blank" rel="noopener noreferrer" href="/privacy">Datenschutzrichtlinie</a>.',
+		'Wir können dir gelegentlich eine kritische Warnung senden, auch wenn du nichts davon auswählst. Siehe unsere <a target="_blank" rel="noopener noreferrer" href="/privacy">Datenschutzrichtlinie</a>.',
 	onboarding_field_country: 'Wohnsitzland *',
 	onboarding_placeholder_country: 'Land auswählen',
 	onboarding_field_city: 'Stadt / Gemeinde *',
@@ -624,7 +624,7 @@ const fr: OnboardingMessages = {
 	onboarding_field_email: 'E-mail *',
 	onboarding_placeholder_email: 'E-mail',
 	onboarding_email_critical_notice:
-		'Nous pouvons occasionnellement vous envoyer une alerte critique, même si vous ne vous inscrivez à rien d\'autre. Voir notre <a target="_blank" rel="noopener noreferrer" href="/privacy">politique de confidentialité</a>.',
+		'Nous pouvons occasionnellement vous envoyer une alerte critique, même si vous n\'en sélectionnez aucune. Voir notre <a target="_blank" rel="noopener noreferrer" href="/privacy">politique de confidentialité</a>.',
 	onboarding_field_country: 'Pays de résidence *',
 	onboarding_placeholder_country: 'Sélectionne ton pays',
 	onboarding_field_city: 'Ville / commune de résidence *',

--- a/src/lib/components/onboarding/messages.ts
+++ b/src/lib/components/onboarding/messages.ts
@@ -11,6 +11,7 @@ export interface OnboardingMessages {
 	onboarding_placeholder_full_name: string
 	onboarding_field_email: string
 	onboarding_placeholder_email: string
+	onboarding_email_critical_notice: string
 	onboarding_field_country: string
 	onboarding_placeholder_country: string
 	onboarding_field_city: string
@@ -188,6 +189,8 @@ const en: OnboardingMessages = {
 	onboarding_placeholder_full_name: 'Full name',
 	onboarding_field_email: 'Email *',
 	onboarding_placeholder_email: 'Email',
+	onboarding_email_critical_notice:
+		'We may occasionally send you a critical alert, even if you don\'t opt into anything else. See our <a target="_blank" rel="noopener noreferrer" href="/privacy">privacy policy</a>.',
 	onboarding_field_country: 'Country of residence *',
 	onboarding_placeholder_country: 'Select your country',
 	onboarding_field_city: 'City / town of residence *',
@@ -398,6 +401,8 @@ const de: OnboardingMessages = {
 	onboarding_placeholder_full_name: 'Vollständiger Name',
 	onboarding_field_email: 'E-Mail *',
 	onboarding_placeholder_email: 'E-Mail',
+	onboarding_email_critical_notice:
+		'Wir senden dir gelegentlich eine kritische Warnung, auch wenn du dich für nichts anderes anmeldest. Siehe unsere <a target="_blank" rel="noopener noreferrer" href="/privacy">Datenschutzrichtlinie</a>.',
 	onboarding_field_country: 'Wohnsitzland *',
 	onboarding_placeholder_country: 'Land auswählen',
 	onboarding_field_city: 'Stadt / Gemeinde *',
@@ -618,6 +623,8 @@ const fr: OnboardingMessages = {
 	onboarding_placeholder_full_name: 'Nom complet',
 	onboarding_field_email: 'E-mail *',
 	onboarding_placeholder_email: 'E-mail',
+	onboarding_email_critical_notice:
+		'Nous pouvons occasionnellement vous envoyer une alerte critique, même si vous ne vous inscrivez à rien d\'autre. Voir notre <a target="_blank" rel="noopener noreferrer" href="/privacy">politique de confidentialité</a>.',
 	onboarding_field_country: 'Pays de résidence *',
 	onboarding_placeholder_country: 'Sélectionne ton pays',
 	onboarding_field_city: 'Ville / commune de résidence *',


### PR DESCRIPTION
Shows the critical-alert notice on the signup form. It was written into the form but commented out, so no signup has ever seen it. Maxime asked for it to be shown.

## Why the checkbox doesn't already cover it

The case is someone who ticks **only the required privacy-policy box** and neither optional box. They are still added to the critical alerts list in CiviCRM, but nothing in the form tells them any email may follow. The required box covers the privacy policy and chapter sharing, and the policy's only email disclosures are the opt-in Substack newsletter and "contact you via Airtable" for coordination.

## Wording

> We may occasionally send you a critical alert, even if you don't opt into any of these. See our [privacy policy].

<img alt="The critical-alert notice under the two opt-in checkboxes on the intent step" src="https://github.com/user-attachments/assets/f857587c-8278-4765-b95b-e0f25273e5ce" width="520" />

"any of these" points at the two checkboxes above it. "critical" and "occasionally" keep this a bounded tier rather than "we may email you anything", which would undercut the opt-in it bypasses. "critical alert" matches the unsubscribe page name (**PauseAI Critical Alerts**) — in English, at least; that page is English-only.

## Implementation

- **Step 2, under the two opt-in checkboxes**, not the email field where the commented-out draft sat: step 1 shows no opt-ins for the clause to point at, and submits nothing (`onsubmit={continueToIntent}`), so no data leaves the browser before step 2.
- **Not on the browse mini-form**, which hardcodes `keep_informed=on` — submitting it *is* the opt-in, so the clause would be false there. Its required privacy-policy checkbox still carries the general disclosure.
- **`aria-describedby` on both controls**, so the notice is not a paragraph a screen-reader user tabs straight past. First use in this file: the other helper texts are hints, this one is a disclosure.
- **`onboarding_email_critical_notice` in `messages.ts` (en/de/fr)** rather than inline English, following `onboarding_gdpr_consent`, which also carries the privacy link as inline markup via `{@html}`.

## Checks

CI green: `pnpm-check`, CodeQL, and a Netlify deploy preview worth clicking through to see it on a real build.

The **de and fr wording is mine and wants a native-speaker read** — four defects surfaced in it during review, which no check here would have caught.

Context: PauseAI/pauseai-civicrm#389 and PauseAI/pauseai-civicrm#344.
