### PR TITLE
Prevent expired banners from rendering server-side

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,10 +166,10 @@ The site has a small banner orchestration system that decides which main banner 
 
 ### How it works
 
-- Selection rules are in `src/routes/banner-selection.cjs`.
-- In `src/routes/+layout.svelte`, `banner-selection.cjs` is injected inline in `<head>`. That script defines `window.selectBanners()` and runs it immediately.
-- The same function is called again in `+layout.svelte` after `/api/geo` updates `geo_country`.
-- Banner components live in `src/routes/+layout.svelte` and are shown/hidden by data attributes on `<html>`.
+- Selection rules live in the `mainBannerRules` / `campaignBannerRules` consts in `src/routes/+layout.svelte`. They are the single source of truth.
+- `+layout.svelte` injects them into `<head>` as globals (`var mainBannerRules` / `var campaignBannerRules`) before the blocking `banner-selection.js` runs.
+- `banner-selection.js` defines `window.selectBanners()` and runs it immediately; it is called again in `+layout.svelte` after `/api/geo` updates `geo_country`.
+- Banner components live in `src/routes/+layout.svelte`. Each orchestrated `<Banner>` receives `rules={mainBannerRules}` so `Banner.svelte` can skip server-rendering expired banners (the inline script still re-checks on the client to handle dismissals and geo). Banners are shown/hidden by data attributes on `<html>`.
 
 ### State used
 
@@ -188,13 +188,11 @@ The site has a small banner orchestration system that decides which main banner 
 
 When adding/changing banners:
 
-1. Add/update the `<Banner id="...">` or `<CampaignBanner id="...">` in `src/routes/+layout.svelte`.
-2. Add/update the matching rule in `src/routes/banner-selection.cjs` with same `id`.
+1. Add/update the `<Banner id="...">` or `<CampaignBanner id="...">` in `src/routes/+layout.svelte`, passing `rules={mainBannerRules}` (or `rules={campaignBannerRules}`).
+2. Add/update the matching entry in the `mainBannerRules` / `campaignBannerRules` const in `src/routes/+layout.svelte` with the same `id`.
 3. Use date format `YYYY-MM-DD` in rule `dateRange`.
 4. Keep intended order: first matching rule wins.
-5. Treat banner IDs as source-of-truth values that must match in both places:
-   - the rule IDs in `mainBannerRules` / `campaignBannerRules` (`src/routes/banner-selection.cjs`)
-   - the `id="..."` props on `<Banner>` / `<CampaignBanner>` in `src/routes/+layout.svelte`
+5. Banner IDs must match between the rule entries and the `id="..."` props on `<Banner>` / `<CampaignBanner>`. Both now live in `src/routes/+layout.svelte`.
 
 ## Latest News Section
 

--- a/src/lib/components/Banner.svelte
+++ b/src/lib/components/Banner.svelte
@@ -5,6 +5,8 @@
 	import { deLocalizeHref } from '$lib/paraglide/runtime'
 	import { setItem } from '$lib/localStorage'
 	import LinkWithoutIcon from '$lib/components/LinkWithoutIcon.svelte'
+	import type { BannerRule } from '$lib/types'
+	import { inDateRange } from '../../routes/inDateRange'
 	import { onMount } from 'svelte'
 
 	interface Props {
@@ -12,10 +14,32 @@
 		href?: string | null
 		id?: string | null
 		type?: 'main' | 'campaign'
+		rules?: BannerRule[] | null
 		children?: import('svelte').Snippet
 	}
 
-	let { children, contrast = false, href = null, id = null, type = 'main' }: Props = $props()
+	let {
+		children,
+		contrast = false,
+		href = null,
+		id = null,
+		type = 'main',
+		rules = null
+	}: Props = $props()
+
+	// Skip rendering on the server when this banner's rule is outside its
+	// date range (not yet started or already expired).
+	// The inline blocking script still re-checks on the client to handle
+	// dismissals and geo, but out-of-range banners never enter the SSR HTML.
+	function ruleOutOfDateRange(): boolean {
+		if (!id || !rules) return false
+		const activeRules: BannerRule[] = rules
+		const rule = activeRules.find((r) => r.id === id)
+		if (!rule) return false
+		return !inDateRange(new Date(), rule.dateRange[0], rule.dateRange[1])
+	}
+
+	let outOfDateRange = $derived(ruleOutOfDateRange())
 
 	// Initialize dismissed state during SSR based on the current pathname
 	const isCurrentPage = (href: string | null) =>
@@ -104,7 +128,7 @@
 	{/if}
 </svelte:head>
 
-{#if !dismissed}
+{#if !dismissed && !outOfDateRange}
 	<div
 		class="banner"
 		class:contrast

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -17,6 +17,17 @@ export type Categories = 'sveltekit' | 'svelte' | 'AI Safety' | 'Transparency' |
 
 export type LinkType = 'internal' | 'external' | 'mail'
 
+/**
+ * A banner selection rule. `dateRange` is `[startsOn, endsOn]` in `YYYY-MM-DD`
+ * format; either bound may be `null` for unbounded. `countries` is `null` for
+ * a global banner, or a list of ISO country codes for geo-targeted banners.
+ */
+export type BannerRule = {
+	id: string
+	dateRange: [string | null, string | null]
+	countries?: string[] | null
+}
+
 type StrictFrontmatterMeta = {
 	title: string
 	/** Overrides title in the page <title> / social meta tags when the on-page H1 should differ */

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -11,6 +11,7 @@
 	import Toc from '$lib/components/Toc.svelte'
 	import { searchOpen } from '$lib/stores/searchModal'
 	import { deLocalizeHref } from '$lib/paraglide/runtime'
+	import type { BannerRule } from '$lib/types'
 	import '@fontsource/roboto-slab/300.css'
 	import '@fontsource/roboto-slab/500.css'
 	import '@fontsource/roboto-slab/700.css'
@@ -29,6 +30,7 @@
 	import bannerSelection from './banner-selection.js?raw'
 	import themeSelection from './theme-selection.js?raw'
 	import hydrationAwareClick from './hydration-aware-click.js?raw'
+	import { inDateRange } from './inDateRange'
 	import type { PageData } from './$types'
 
 	interface Props {
@@ -37,6 +39,30 @@
 	}
 
 	let { data, children }: Props = $props()
+
+	const mainBannerRules: BannerRule[] = [
+		{
+			id: 'gb-feb28-protest',
+			countries: ['GB'],
+			dateRange: [null, '2025-02-28']
+		},
+		{
+			id: 'us-state-sovereignty',
+			countries: ['US'],
+			dateRange: [null, '2025-02-28']
+		},
+		{
+			id: 'holiday-littlehelpers',
+			countries: null,
+			dateRange: [null, '2024-12-31']
+		},
+		{
+			id: 'pausecon-london-2026',
+			countries: null,
+			dateRange: [null, '2026-08-21']
+		}
+	]
+	const campaignBannerRules: BannerRule[] = []
 
 	let eventFound: boolean = $state(false)
 	let geoForNearbyEvent: GeoApiResponse | null = $state(null)
@@ -94,32 +120,14 @@
 </script>
 
 <svelte:head>
-	<script>
-		var mainBannerRules = [
-			{
-				id: 'gb-feb28-protest',
-				countries: ['GB'],
-				dateRange: [null, '2025-02-28']
-			},
-			{
-				id: 'us-state-sovereignty',
-				countries: ['US'],
-				dateRange: [null, '2025-02-28']
-			},
-			{
-				id: 'holiday-littlehelpers',
-				countries: null,
-				dateRange: [null, '2024-12-31']
-			},
-			{
-				id: 'pausecon-london-2026',
-				countries: null,
-				dateRange: [null, '2026-08-21']
-			}
-		]
-
-		var campaignBannerRules = []
-	</script>
+	<!-- eslint-disable-next-line svelte/no-unused-svelte-ignore -- doesn't warn at compile time -->
+	<!-- svelte-ignore hydration_html_changed -- the stringified function looks different on client and server -->
+	<!-- eslint-disable-next-line svelte/no-at-html-tags -- not vulnerable against XSS -->
+	{@html `<${'script'}>${sanitizeScript(
+		`var mainBannerRules = ${JSON.stringify(mainBannerRules)}
+		var campaignBannerRules = ${JSON.stringify(campaignBannerRules)}
+		var inDateRange = ${inDateRange.toString()}`
+	)}</script>`}
 
 	<!-- eslint-disable-next-line svelte/no-at-html-tags not vulnerable against XSS -->
 	{@html `<${'script'}>${sanitizeScript(themeSelection)}</script>`}
@@ -151,28 +159,33 @@
 		{/if}
 
 		<!-- All banners rendered, hidden by default. Blocking script reveals the active main/campaign banner. -->
-		<Banner contrast={hero} id="gb-feb28-protest">
+		<Banner contrast={hero} id="gb-feb28-protest" rules={mainBannerRules}>
 			<b
 				>PauseAI's largest ever protest will be on Saturday February 28th in London. <Link
 					href="https://luma.com/o0p4htmk">Sign up now!</Link
 				></b
 			>
 		</Banner>
-		<Banner contrast={hero} id="us-state-sovereignty">
+		<Banner contrast={hero} id="us-state-sovereignty" rules={mainBannerRules}>
 			<b
 				>HELP US PROTECT STATE SOVEREIGNTY ON AI REGULATION | <Link
 					href="https://mstr.app/b09fa92b-1899-43a0-9d95-99cd99c9dfb2">ACT NOW »</Link
 				></b
 			>
 		</Banner>
-		<Banner contrast={hero} id="holiday-littlehelpers" href="/littlehelpers">
+		<Banner
+			contrast={hero}
+			id="holiday-littlehelpers"
+			href="/littlehelpers"
+			rules={mainBannerRules}
+		>
 			<strong>🎄 Holiday Matching Campaign!</strong> Help fund volunteer stipends for PauseAI
 			advocates. <Link href="/littlehelpers">Join the Little Helpers campaign →</Link>
 		</Banner>
 
 		<NearbyEvent contrast={hero} bind:eventFound geo={geoForNearbyEvent} />
 
-		<Banner contrast={hero} id="pausecon-london-2026">
+		<Banner contrast={hero} id="pausecon-london-2026" rules={mainBannerRules}>
 			<strong>PauseCon London 2026</strong>: Apply now to join our September organising conference.
 			<strong><Link href="https://luma.com/4be2eqz9">Apply here!</Link></strong>
 		</Banner>

--- a/src/routes/banner-selection.js
+++ b/src/routes/banner-selection.js
@@ -13,7 +13,7 @@ var mainBannerRules
 // eslint-disable-next-line no-unassigned-vars -- Injected by +layout.svelte at runtime
 var campaignBannerRules
 /** @type {(now: Date, startsOn: string | null, endsOn: string | null) => boolean} */
-// eslint-disable-next-line no-undef -- Injected by +layout.svelte at runtime
+// eslint-disable-next-line no-unassigned-vars -- Injected by +layout.svelte at runtime
 var inDateRange
 
 window.selectBanners = function () {

--- a/src/routes/banner-selection.js
+++ b/src/routes/banner-selection.js
@@ -2,19 +2,19 @@
 // Reads geo from cookie, checks dates + dismissals, sets data-active-banner,
 // data-is-active-banner-geo, and data-active-campaign-banner on <html>.
 // Exposed as window.selectBanners to allow re-runs.
+//
+// `inDateRange` is injected as a global by +layout.svelte before this script runs.
 
-/**
- * @typedef {Object} BannerRule
- * @property {string} id
- * @property {[string | null, string | null]} dateRange
- * @property {string[]=} countries
- */
+/** @typedef {import('$lib/types').BannerRule} BannerRule */
 /** @type {BannerRule[]} */
 // eslint-disable-next-line no-unassigned-vars -- Injected by +layout.svelte at runtime
 var mainBannerRules
 /** @type {BannerRule[]} */
 // eslint-disable-next-line no-unassigned-vars -- Injected by +layout.svelte at runtime
 var campaignBannerRules
+/** @type {(now: Date, startsOn: string | null, endsOn: string | null) => boolean} */
+// eslint-disable-next-line no-undef -- Injected by +layout.svelte at runtime
+var inDateRange
 
 window.selectBanners = function () {
 	var now = new Date()
@@ -37,25 +37,6 @@ window.selectBanners = function () {
 	}
 
 	/**
-	 * @param {string | null} startsOn
-	 * @param {string | null} endsOn
-	 * @returns {boolean}
-	 */
-	function inDateRange(startsOn, endsOn) {
-		if (startsOn) {
-			/** @type {string[]} */
-			var s = startsOn.split('-')
-			if (now < new Date(+s[0], +s[1] - 1, +s[2])) return false
-		}
-		if (endsOn) {
-			/** @type {string[]} */
-			var e = endsOn.split('-')
-			if (now > new Date(+e[0], +e[1] - 1, +e[2], 23, 59, 59, 999)) return false
-		}
-		return true
-	}
-
-	/**
 	 * @param {BannerRule[]} rules
 	 * @param {string} dismissalPrefix
 	 * @returns {BannerRule | undefined}
@@ -65,7 +46,7 @@ window.selectBanners = function () {
 			var countryMatches = !rule.countries || rule.countries.indexOf(country) !== -1
 			if (
 				countryMatches &&
-				inDateRange(...rule.dateRange) &&
+				inDateRange(now, rule.dateRange[0], rule.dateRange[1]) &&
 				!dismissed(dismissalPrefix, rule.id)
 			) {
 				return true

--- a/src/routes/inDateRange.ts
+++ b/src/routes/inDateRange.ts
@@ -1,0 +1,25 @@
+// Shared date-range check for banner rules.
+// Used by:
+//   - Banner.svelte (SSR expiry check, imported normally)
+//   - banner-selection.js (inline blocking script, injected via .toString())
+//
+// Vite compiles this to JS before bundling, so .toString() on the imported
+// function still produces valid plain JS for the inline <script> tag.
+
+/**
+ * @param {Date} now
+ * @param {string | null} startsOn  - YYYY-MM-DD or null (unbounded)
+ * @param {string | null} endsOn    - YYYY-MM-DD or null (unbounded)
+ * @returns {boolean} - true if `now` is within [start-of-startsOn, end-of-endsOn]
+ */
+export function inDateRange(now: Date, startsOn: string | null, endsOn: string | null): boolean {
+	if (startsOn) {
+		const s = startsOn.split('-')
+		if (now < new Date(+s[0], +s[1] - 1, +s[2])) return false
+	}
+	if (endsOn) {
+		const e = endsOn.split('-')
+		if (now > new Date(+e[0], +e[1] - 1, +e[2], 23, 59, 59, 999)) return false
+	}
+	return true
+}


### PR DESCRIPTION
## Summary

Banners whose date range has not yet started or has already expired were being server-rendered into the SSR HTML and then hidden by the blocking client-side `banner-selection.js` script. The expired banner markup was still present in the served HTML, meaning crawlers and other consumers of the raw document would pick up outdated content (e.g. announcements for protests that already happened).

This PR moves banner rules into a single source of truth in `+layout.svelte`, shares an `inDateRange` helper between SSR and the inline client script, and skips rendering out-of-range banners during SSR so they never enter the HTML document at all.

## Changes

- **`src/routes/inDateRange.ts`** (new): Shared date-range check used by both `Banner.svelte` (SSR) and `banner-selection.js` (inline client script via `.toString()`).
- **`src/lib/types.ts`**: Adds the `BannerRule` type (`id`, `dateRange`, `countries`).
- **`src/lib/components/Banner.svelte`**: Accepts a `rules` prop and skips SSR rendering when the banner's rule is outside its date range. The inline client script still re-checks to handle dismissals and geo.
- **`src/routes/+layout.svelte`**: Moves `mainBannerRules` / `campaignBannerRules` into typed consts (single source of truth), injects them plus `inDateRange` into `<head>` as globals before `banner-selection.js` runs, and passes `rules={mainBannerRules}` to each `<Banner>`.
- **`src/routes/banner-selection.js`**: Removes the duplicated `inDateRange` implementation; now consumes the injected global. Updates the `BannerRule` typedef to import from `$lib/types`.
- **`README.md`**: Updates the banner orchestration docs to reflect the new single-source-of-truth location and SSR expiry behavior.

## How to test

1. Confirm expired banners (e.g. `gb-feb28-protest`, `us-state-sovereignty`, `holiday-littlehelpers`) no longer appear in the server-rendered HTML source.
2. Confirm the active in-range banner (`pausecon-london-2026`) still renders and is revealed correctly.
3. Confirm banner dismissal and geo-targeting still work after the client script re-runs.
4. Confirm no hydration mismatch warnings in the console.

## Notes

- The inline `<script>` is emitted via `{@html}` with `sanitizeScript`; `inDateRange` is serialized via `.toString()` so the same logic runs client-side without a duplicate implementation.
- A `hydration_html_changed` svelte-ignore is added because the stringified function body differs between server and client builds.