### PR TITLE
Allow markdown posts to opt out of prerendering and load URL-backed data

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,42 @@ The article (and automatic l10ns of same) will be previewable.
 
 If you are sufficiently changing prominent text, consider inspecting relevant l10ns as well as the original.
 
+### Loading Data in Markdown Posts
+
+Markdown posts can fetch URL-backed data on the server by adding a `data` map to frontmatter. This is most useful for internal API routes:
+
+```markdown
+---
+title: Example
+description: Example post
+data:
+  news: /api/news?page=1&pageSize=3
+---
+
+<script lang="ts">
+	export let data
+</script>
+
+{#each data.news.items as item}
+<h2>{item.title}</h2>
+<p>{item.subtitle}</p>
+{/each}
+```
+
+Each value in the `data` map must be a URL. JSON responses are parsed and all other responses are passed through as text. The loaded values are passed into the mdsvex component as the `data` prop.
+
+By default, Markdown posts are prerendered, so these URLs are fetched during the production build and the result is baked into static HTML. Combine `data` with `prerender: false` when the data should be fetched at request time, such as for frequently changing API responses or routes that depend on runtime environment:
+
+```yaml
+---
+title: Live Example
+description: Example post with request-time data.
+prerender: false
+data:
+  news: /api/news?page=1&pageSize=3
+---
+```
+
 ### Image Optimization
 
 Images are processed at build time by [`vite-imagetools`](https://github.com/JonasKruckenberg/imagetools) and delivered in multiple formats (AVIF, WebP) and resolutions via a `<picture>` element. Remote or arbitrary images are optimized at request time by the [Netlify image CDN](https://docs.netlify.com/image-cdn/).

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -40,6 +40,8 @@ type StrictFrontmatterMeta = {
 	categories?: Categories[]
 	image?: string
 	showImage?: boolean
+	/** If false, this post will be dynamically rendered instead of prerendered at build time */
+	prerender?: boolean
 	/** If true, this post will appear in the Latest News section on the homepage */
 	news?: boolean
 	/**

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -17,6 +17,8 @@ export type Categories = 'sveltekit' | 'svelte' | 'AI Safety' | 'Transparency' |
 
 export type LinkType = 'internal' | 'external' | 'mail'
 
+export type FrontmatterDataSources = Record<string, string>
+
 /**
  * A banner selection rule. `dateRange` is `[startsOn, endsOn]` in `YYYY-MM-DD`
  * format; either bound may be `null` for unbounded. `countries` is `null` for
@@ -42,6 +44,8 @@ type StrictFrontmatterMeta = {
 	showImage?: boolean
 	/** If false, this post will be dynamically rendered instead of prerendered at build time */
 	prerender?: boolean
+	/** Named URLs to fetch server-side and pass to the mdsvex component as a `data` prop */
+	data?: FrontmatterDataSources
 	/** If true, this post will appear in the Latest News section on the homepage */
 	news?: boolean
 	/**

--- a/src/routes/[slug]/+page.server.ts
+++ b/src/routes/[slug]/+page.server.ts
@@ -1,6 +1,8 @@
 import { getLocale } from '$lib/paraglide/runtime'
+import { generateCacheControlRecord } from '$lib/utils'
 import type { DescriptiveFrontmatterMeta } from '$lib/types'
 import { dataForPost } from './frontmatter-data.server'
+import { importMarkdown } from './markdown'
 import { cssForPost } from './post-css.server'
 import { imagesForPost } from './post-images.server'
 import type { EntryGenerator, PageServerLoad } from './$types'
@@ -20,13 +22,20 @@ export const entries: EntryGenerator = () =>
 
 export const prerender = 'auto'
 
-export const load: PageServerLoad = async ({ params: { slug }, fetch }) => {
+export const load: PageServerLoad = async ({ params: { slug }, fetch, setHeaders }) => {
 	const locale = getLocale()
 	const cssUrls = cssForPost(slug, locale)
-	const [{ pictures, banner, metaImageUrl }, frontmatterData] = await Promise.all([
+	const [{ pictures, banner, metaImageUrl }, frontmatterData, { metadata }] = await Promise.all([
 		imagesForPost(locale, slug),
-		dataForPost(locale, slug, fetch)
+		dataForPost(locale, slug, fetch),
+		importMarkdown(locale, slug)
 	])
+
+	// Dynamically rendered posts (prerender: false) benefit from a cache header
+	// so CDN/edge caches can serve repeated requests without hitting the origin.
+	if (metadata.prerender === false) {
+		setHeaders(generateCacheControlRecord({ public: true, maxAge: 60 * 60 }))
+	}
 
 	return { cssUrls, pictures, banner, metaImageUrl, frontmatterData }
 }

--- a/src/routes/[slug]/+page.server.ts
+++ b/src/routes/[slug]/+page.server.ts
@@ -1,5 +1,6 @@
 import { getLocale } from '$lib/paraglide/runtime'
 import type { DescriptiveFrontmatterMeta } from '$lib/types'
+import { dataForPost } from './frontmatter-data.server'
 import { cssForPost } from './post-css.server'
 import { imagesForPost } from './post-images.server'
 import type { EntryGenerator, PageServerLoad } from './$types'
@@ -19,12 +20,15 @@ export const entries: EntryGenerator = () =>
 
 export const prerender = 'auto'
 
-export const load: PageServerLoad = async ({ params: { slug } }) => {
+export const load: PageServerLoad = async ({ params: { slug }, fetch }) => {
 	const locale = getLocale()
 	const cssUrls = cssForPost(slug, locale)
-	const { pictures, banner, metaImageUrl } = await imagesForPost(locale, slug)
+	const [{ pictures, banner, metaImageUrl }, frontmatterData] = await Promise.all([
+		imagesForPost(locale, slug),
+		dataForPost(locale, slug, fetch)
+	])
 
-	return { cssUrls, pictures, banner, metaImageUrl }
+	return { cssUrls, pictures, banner, metaImageUrl, frontmatterData }
 }
 
 function slugFromPostPath(path: string): string {

--- a/src/routes/[slug]/+page.server.ts
+++ b/src/routes/[slug]/+page.server.ts
@@ -1,7 +1,23 @@
 import { getLocale } from '$lib/paraglide/runtime'
+import type { DescriptiveFrontmatterMeta } from '$lib/types'
 import { cssForPost } from './post-css.server'
 import { imagesForPost } from './post-images.server'
-import type { PageServerLoad } from './$types'
+import type { EntryGenerator, PageServerLoad } from './$types'
+
+type MarkdownEntryModule = {
+	metadata?: DescriptiveFrontmatterMeta
+}
+
+const postModules = import.meta.glob<MarkdownEntryModule>('/src/posts/*.md', {
+	eager: true
+})
+
+export const entries: EntryGenerator = () =>
+	Object.entries(postModules)
+		.filter(([, post]) => post.metadata?.prerender !== false)
+		.map(([path]) => ({ slug: slugFromPostPath(path) }))
+
+export const prerender = 'auto'
 
 export const load: PageServerLoad = async ({ params: { slug } }) => {
 	const locale = getLocale()
@@ -9,4 +25,8 @@ export const load: PageServerLoad = async ({ params: { slug } }) => {
 	const { pictures, banner, metaImageUrl } = await imagesForPost(locale, slug)
 
 	return { cssUrls, pictures, banner, metaImageUrl }
+}
+
+function slugFromPostPath(path: string): string {
+	return path.slice(path.lastIndexOf('/') + 1, -'.md'.length)
 }

--- a/src/routes/[slug]/+page.svelte
+++ b/src/routes/[slug]/+page.svelte
@@ -64,7 +64,7 @@
 	{/if}
 
 	<div class="prose">
-		<data.content />
+		<data.content data={data.frontmatterData ?? {}} />
 	</div>
 </article>
 

--- a/src/routes/[slug]/frontmatter-data.server.ts
+++ b/src/routes/[slug]/frontmatter-data.server.ts
@@ -1,0 +1,44 @@
+import type { FrontmatterDataSources } from '$lib/types'
+import { importMarkdown } from './markdown'
+
+export type FrontmatterData = Record<string, unknown>
+
+type ServerFetch = typeof fetch
+
+export async function dataForPost(
+	locale: string,
+	slug: string,
+	fetch: ServerFetch
+): Promise<FrontmatterData> {
+	const { metadata } = await importMarkdown(locale, slug)
+	return fetchFrontmatterData(metadata.data, fetch)
+}
+
+async function fetchFrontmatterData(
+	sources: FrontmatterDataSources | undefined,
+	fetch: ServerFetch
+): Promise<FrontmatterData> {
+	if (!sources) return {}
+
+	const entries: [string, unknown][] = await Promise.all(
+		Object.entries(sources).map(async ([key, url]) => [
+			key,
+			await fetchFrontmatterUrl(key, url, fetch)
+		])
+	)
+	return Object.fromEntries(entries)
+}
+
+async function fetchFrontmatterUrl(key: string, url: string, fetch: ServerFetch): Promise<unknown> {
+	const response = await fetch(url)
+	if (!response.ok) {
+		throw new Error(`Frontmatter data source "${key}" failed: ${response.status} ${url}`)
+	}
+
+	const contentType = response.headers.get('content-type') ?? ''
+	if (contentType.includes('application/json')) {
+		return response.json()
+	}
+
+	return response.text()
+}


### PR DESCRIPTION
## Summary

Markdown posts can now opt out of prerendering and fetch URL-backed data at request time via a frontmatter `data` map.

Resolves the tradeoff raised in #1023 (comment): markdown posts had no `load` function available, so components like `AboutPeople` had to fetch data client-side after mount, leaving the people list absent from server-rendered HTML and unindexable by crawlers. This PR gives markdown posts a server-side data-loading path via frontmatter `data`, so that content can be fetched during SSR and included in the initial HTML.

## Changes

- **Allow markdown posts to opt out of prerendering** — posts can set `prerender: false` in frontmatter to be dynamically rendered instead of baked into static HTML at build time.
- **Load URL-backed data in markdown posts via frontmatter `data` map** — a new `data` frontmatter field maps names to URLs that are fetched server-side and passed to the mdsvex component as a `data` prop. JSON responses are parsed; other responses are passed through as text. Documented in `README.md`.
- **Cache dynamically rendered posts for 1 hour** — non-prerendered posts now set `Cache-Control: public, max-age=3600` so CDN/edge caches can serve repeated requests without hitting the origin.

## Usage

```markdown
---
title: Live Example
description: Example post with request-time data.
prerender: false
data:
  news: /api/news?page=1&pageSize=3
---

{#each data.news.items as item}
<h2>{item.title}</h2>
{/each}
```