### PR TITLE
Add Turnstile verification to the contact forms

### DIFF
--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -1,4 +1,5 @@
 import type { Locale } from '$lib/paraglide/runtime.js'
+import type { TurnstileApi } from '$lib/turnstile'
 import type { Context } from '@netlify/edge-functions'
 import type { Picture } from 'vite-imagetools'
 // See https://kit.svelte.dev/docs/types#app
@@ -29,6 +30,8 @@ declare global {
 		selectBanners(): void
 		applyTheme(): void
 		dataLayer?: unknown[]
+		turnstile?: TurnstileApi
+		onPauseAITurnstileLoad?: () => void
 	}
 
 	declare module '*.md' {

--- a/src/lib/components/Turnstile.svelte
+++ b/src/lib/components/Turnstile.svelte
@@ -1,0 +1,87 @@
+<script lang="ts">
+	import { onMount } from 'svelte'
+	import {
+		loadTurnstile,
+		TURNSTILE_FIELD,
+		turnstileSiteKey,
+		type TurnstileApi
+	} from '$lib/turnstile'
+
+	// Tokens are single-use and expire after five minutes, so the parent remounts
+	// this component (via a {#key} block) after every submission.
+	let { token = $bindable('') }: { token: string } = $props()
+
+	let container = $state<HTMLDivElement | undefined>(undefined)
+	let failed = $state(false)
+
+	let api: TurnstileApi | undefined
+	let widgetId: string | undefined
+
+	onMount(() => {
+		const target = container
+		if (!turnstileSiteKey || !target) return
+
+		let cancelled = false
+
+		loadTurnstile()
+			.then((turnstile) => {
+				if (cancelled) return
+				api = turnstile
+				widgetId = turnstile.render(target, {
+					sitekey: turnstileSiteKey,
+					theme: 'auto',
+					callback: (newToken: string) => {
+						token = newToken
+						failed = false
+					},
+					'error-callback': () => {
+						token = ''
+						failed = true
+					},
+					'expired-callback': () => {
+						token = ''
+					}
+				})
+			})
+			.catch((error: unknown) => {
+				console.error('Turnstile failed to load:', error)
+				failed = true
+			})
+
+		return () => {
+			cancelled = true
+			if (api && widgetId) api.remove(widgetId)
+		}
+	})
+</script>
+
+{#if turnstileSiteKey}
+	<div class="turnstile">
+		<div bind:this={container}></div>
+		{#if failed}
+			<p class="turnstile-error">
+				The anti-spam check could not load. Please refresh the page and try again.
+			</p>
+		{/if}
+	</div>
+{/if}
+<input type="hidden" name={TURNSTILE_FIELD} value={token} />
+
+<style>
+	.turnstile {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		gap: 0.5rem;
+		/* Reserve the widget's height so the form does not jump as it loads. */
+		min-height: 65px;
+	}
+
+	.turnstile-error {
+		margin: 0;
+		font-size: 0.9rem;
+		color: var(--text);
+		opacity: 0.8;
+		text-align: center;
+	}
+</style>

--- a/src/lib/turnstile.ts
+++ b/src/lib/turnstile.ts
@@ -1,0 +1,48 @@
+// Static (build-time) env on purpose: $env/dynamic/public in any client chunk
+// makes prerendered pages block hydration on a runtime fetch of /_app/env.js
+// from the SSR function. See the same note in hooks.client.ts.
+import * as publicEnv from '$env/static/public'
+
+export type TurnstileApi = {
+	render: (element: HTMLElement, options: Record<string, unknown>) => string
+	reset: (widgetId: string) => void
+	remove: (widgetId: string) => void
+}
+
+/** Public by design — it has to appear in the page for the widget to render. */
+export const turnstileSiteKey = (publicEnv as Record<string, string | undefined>)
+	.PUBLIC_TURNSTILE_SITE_KEY
+
+/**
+ * Our own field name for the token, rather than Turnstile's auto-injected
+ * `cf-turnstile-response`, so a form can never end up with two same-named inputs.
+ */
+export const TURNSTILE_FIELD = 'turnstile_token'
+
+const ONLOAD_CALLBACK = 'onPauseAITurnstileLoad'
+
+let loadPromise: Promise<TurnstileApi> | undefined
+
+/** Loads api.js once per page, however many widgets mount. */
+export function loadTurnstile(): Promise<TurnstileApi> {
+	loadPromise ??= new Promise<TurnstileApi>((resolve, reject) => {
+		if (window.turnstile) {
+			resolve(window.turnstile)
+			return
+		}
+
+		window[ONLOAD_CALLBACK] = () => {
+			if (window.turnstile) resolve(window.turnstile)
+			else reject(new Error('Turnstile loaded without exposing its API'))
+		}
+
+		const script = document.createElement('script')
+		script.src = `https://challenges.cloudflare.com/turnstile/v0/api.js?render=explicit&onload=${ONLOAD_CALLBACK}`
+		script.async = true
+		script.defer = true
+		script.onerror = () => reject(new Error('Failed to load Turnstile'))
+		document.head.append(script)
+	})
+
+	return loadPromise
+}

--- a/src/routes/contact-us/+page.server.ts
+++ b/src/routes/contact-us/+page.server.ts
@@ -1,7 +1,10 @@
 import { fail } from '@sveltejs/kit'
 import type { Actions } from './$types'
+import { dev } from '$app/environment'
 import { env } from '$env/dynamic/private'
 import { createRecord } from '$lib/airtable'
+import { TURNSTILE_FIELD } from '$lib/turnstile'
+import { partnershipOptions } from './partnership-options'
 
 // Airtable configuration (User to fill in later)
 const CONTACT_AIRTABLE_BASE_ID = 'appWPTGqZmUcs3NWu'
@@ -11,7 +14,6 @@ export const prerender = false
 
 // Configure recipient email addresses for each contact form type
 const CONTACT_RECIPIENTS = {
-	Standard: 'contact@pauseai.info',
 	Media: 'press@pauseai.info',
 	Partnerships: 'partnerships@pauseai.info',
 	Feedback: 'feedback@pauseai.info'
@@ -19,11 +21,32 @@ const CONTACT_RECIPIENTS = {
 
 const mailerSendApiKey = env.MAILERSEND_API_KEY
 
+const TURNSTILE_VERIFY_URL = 'https://challenges.cloudflare.com/turnstile/v0/siteverify'
+
+/**
+ * Maximum characters accepted per field. The client shows softer hints, but these
+ * are the limits that count: bots POST straight to the action and never run our JS.
+ */
+const MAX_LENGTHS: Record<string, number> = {
+	name: 100,
+	email: 254,
+	subject: 200,
+	organization: 200,
+	city_country: 200,
+	message: 5000,
+	details: 5000,
+	other_partnership_type: 200
+}
+
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+
 type ContactFormType = keyof typeof CONTACT_RECIPIENTS
 
 type MailerSendError = {
 	message?: string
 }
+
+type TurnstileVerification = { success?: boolean; 'error-codes'?: unknown }
 
 function getFormString(formData: FormData, field: string): string | undefined {
 	const value = formData.get(field)
@@ -32,6 +55,98 @@ function getFormString(formData: FormData, field: string): string | undefined {
 
 function isMailerSendError(value: unknown): value is MailerSendError {
 	return typeof value === 'object' && value !== null
+}
+
+function isTurnstileVerification(value: unknown): value is TurnstileVerification {
+	return typeof value === 'object' && value !== null
+}
+
+function escapeHtml(value: string): string {
+	return value
+		.replace(/&/g, '&amp;')
+		.replace(/</g, '&lt;')
+		.replace(/>/g, '&gt;')
+		.replace(/"/g, '&quot;')
+		.replace(/'/g, '&#39;')
+}
+
+function countWords(value: string): number {
+	return value.trim().split(/\s+/).filter(Boolean).length
+}
+
+/** Returns an error message if any submitted field exceeds its cap. */
+function findOversizedField(formData: FormData): string | undefined {
+	for (const [field, max] of Object.entries(MAX_LENGTHS)) {
+		const value = getFormString(formData, field)
+		if (value && value.length > max) {
+			return `The ${field.replace(/_/g, ' ')} field is too long (maximum ${max} characters).`
+		}
+	}
+	return undefined
+}
+
+/**
+ * Verifies the Cloudflare Turnstile token server-side. This is the check that
+ * matters — the honeypot only catches bots that render the page, whereas most
+ * spam POSTs directly to the form action.
+ */
+async function verifyTurnstile(
+	token: string | undefined
+): Promise<{ ok: true } | { ok: false; message: string }> {
+	const secret = env.TURNSTILE_SECRET_KEY
+
+	if (!secret) {
+		// `dev` (not isDev()) on purpose: it is compiled to a constant false in any
+		// build, so whether we fail closed does not depend on which env vars the
+		// runtime happens to expose. isDev() keys off CI at request time, which is
+		// too fragile a basis for a security decision.
+		if (dev) {
+			console.warn('⚠️ TURNSTILE_SECRET_KEY not set — skipping anti-spam check in development')
+			return { ok: true }
+		}
+		// Fail closed: a misconfigured deploy must not silently reopen the form to bots.
+		console.error('TURNSTILE_SECRET_KEY is not configured')
+		return {
+			ok: false,
+			message: 'Spam protection is unavailable. Please email contact@pauseai.info instead.'
+		}
+	}
+
+	if (!token) {
+		return {
+			ok: false,
+			message: 'Please wait for the anti-spam check to complete, then send your message again.'
+		}
+	}
+
+	try {
+		const response = await fetch(TURNSTILE_VERIFY_URL, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+			body: new URLSearchParams({ secret, response: token })
+		})
+
+		const result: unknown = await response.json()
+
+		if (isTurnstileVerification(result) && result.success === true) {
+			return { ok: true }
+		}
+
+		console.warn(
+			'Turnstile rejected a submission:',
+			isTurnstileVerification(result) ? result['error-codes'] : result
+		)
+		return {
+			ok: false,
+			message: 'The anti-spam check failed. Please reload the page and try again.'
+		}
+	} catch (error) {
+		console.error('Turnstile verification error:', error)
+		return {
+			ok: false,
+			message: 'Could not complete the anti-spam check. Please try again in a moment.'
+		}
+	}
 }
 
 async function sendContactEmail(data: {
@@ -53,21 +168,23 @@ async function sendContactEmail(data: {
 
 	const recipientEmail = CONTACT_RECIPIENTS[data.type]
 
+	// Everything interpolated below is attacker-controlled, so it is escaped:
+	// unescaped input let spammers inject live links into the team's inbox.
 	let htmlContent = `
-		<p><strong>Name:</strong> ${data.name}</p>
-		<p><strong>Email:</strong> ${data.email}</p>
-		<p><strong>Subject:</strong> ${data.subject}</p>
+		<p><strong>Name:</strong> ${escapeHtml(data.name)}</p>
+		<p><strong>Email:</strong> ${escapeHtml(data.email)}</p>
+		<p><strong>Subject:</strong> ${escapeHtml(data.subject)}</p>
 	`
 
 	if (data.organization) {
-		htmlContent += `<p><strong>Organization:</strong> ${data.organization}</p>`
+		htmlContent += `<p><strong>Organization:</strong> ${escapeHtml(data.organization)}</p>`
 	}
 
 	if (data.city_country) {
-		htmlContent += `<p><strong>City, Country:</strong> ${data.city_country}</p>`
+		htmlContent += `<p><strong>City, Country:</strong> ${escapeHtml(data.city_country)}</p>`
 	}
 
-	htmlContent += `<p><strong>Message:</strong></p><p>${data.message.replace(/\n/g, '<br>')}</p>`
+	htmlContent += `<p><strong>Message:</strong></p><p>${escapeHtml(data.message).replace(/\n/g, '<br>')}</p>`
 
 	const textContent = `Name: ${data.name}\nEmail: ${data.email}\nSubject: ${data.subject}${data.organization ? `\nOrganization: ${data.organization}` : ''}${data.city_country ? `\nCity, Country: ${data.city_country}` : ''}\n\nMessage:\n${data.message}`
 
@@ -191,54 +308,45 @@ async function sendConfirmationEmail(data: { name: string; email: string; type: 
 	}
 }
 
+/**
+ * The anti-bot gate shared by every form, cheapest check first.
+ * `drop` means silently pretend success, so a bot does not learn it was caught.
+ */
+async function checkNotSpam(
+	data: FormData
+): Promise<{ drop: true } | { drop: false; message?: string }> {
+	// Hidden field that only an automated form-filler completes.
+	if (getFormString(data, 'nickname')) return { drop: true }
+
+	const verification = await verifyTurnstile(getFormString(data, TURNSTILE_FIELD))
+	if (!verification.ok) return { drop: false, message: verification.message }
+
+	return { drop: false }
+}
+
 export const actions: Actions = {
-	standard: async ({ request }) => {
-		const data = await request.formData()
-		const name = getFormString(data, 'name')
-		const email = getFormString(data, 'email')
-		const subject = getFormString(data, 'subject')
-		const message = getFormString(data, 'message')
-		const nickname = getFormString(data, 'nickname')
-
-		if (nickname) {
-			return { success: true }
-		}
-
-		if (!name || !email || !subject || !message) {
-			return fail(400, { message: 'Missing required fields' })
-		}
-
-		const result = await sendContactEmail({
-			name,
-			email,
-			subject,
-			message,
-			type: 'Standard'
-		})
-
-		if (!result.success) {
-			return fail(500, { message: result.message })
-		}
-
-		await sendConfirmationEmail({ name, email, type: 'Standard' })
-
-		return { success: true }
-	},
 	media: async ({ request }) => {
 		const data = await request.formData()
+
+		const spam = await checkNotSpam(data)
+		if (spam.drop) return { success: true }
+		if (spam.message) return fail(403, { message: spam.message })
+
+		const oversized = findOversizedField(data)
+		if (oversized) return fail(400, { message: oversized })
+
 		const name = getFormString(data, 'name')
 		const email = getFormString(data, 'email')
 		const subject = getFormString(data, 'subject')
 		const organization = getFormString(data, 'organization')
 		const details = getFormString(data, 'details')
-		const nickname = getFormString(data, 'nickname')
-
-		if (nickname) {
-			return { success: true }
-		}
 
 		if (!name || !email || !subject || !organization || !details) {
 			return fail(400, { message: 'Missing required fields' })
+		}
+
+		if (!EMAIL_PATTERN.test(email)) {
+			return fail(400, { message: 'Please enter a valid email address.' })
 		}
 
 		const result = await sendContactEmail({
@@ -260,27 +368,49 @@ export const actions: Actions = {
 	},
 	partnerships: async ({ request }) => {
 		const data = await request.formData()
+
+		const spam = await checkNotSpam(data)
+		if (spam.drop) return { success: true }
+		if (spam.message) return fail(403, { message: spam.message })
+
+		const oversized = findOversizedField(data)
+		if (oversized) return fail(400, { message: oversized })
+
 		const name = getFormString(data, 'name')
 		const email = getFormString(data, 'email')
 		const organization = getFormString(data, 'organization')
 		const city_country = getFormString(data, 'city_country')
-
-		let subject = getFormString(data, 'partnership_type') ?? ''
-		const other_type = getFormString(data, 'other_partnership_type')
-
-		if (subject === 'Other' && other_type) {
-			subject = `Other: ${other_type}`
-		}
-
 		const message = getFormString(data, 'message')
-		const nickname = getFormString(data, 'nickname')
 
-		if (nickname) {
-			return { success: true }
+		// The form offers a fixed list, so anything else was not sent by our UI.
+		const partnershipType = getFormString(data, 'partnership_type') ?? ''
+		if (!partnershipOptions.includes(partnershipType)) {
+			return fail(400, { message: 'Please choose how you would like to partner with us.' })
 		}
 
-		if (!name || !email || !city_country || !subject || !message) {
+		let subject = partnershipType
+		if (partnershipType === 'Other') {
+			const otherType = getFormString(data, 'other_partnership_type')
+			if (!otherType) {
+				return fail(400, { message: 'Please describe the type of partnership.' })
+			}
+			if (countWords(otherType) > 10) {
+				return fail(400, { message: 'Other partnership type must be 10 words or less.' })
+			}
+			subject = `Other: ${otherType}`
+		}
+
+		if (!name || !email || !city_country || !message) {
 			return fail(400, { message: 'Missing required fields' })
+		}
+
+		if (!EMAIL_PATTERN.test(email)) {
+			return fail(400, { message: 'Please enter a valid email address.' })
+		}
+
+		const messageWords = countWords(message)
+		if (messageWords > 200) {
+			return fail(400, { message: `Message must be 200 words or less. (Sent: ${messageWords})` })
 		}
 
 		const result = await sendContactEmail({
@@ -303,18 +433,26 @@ export const actions: Actions = {
 	},
 	feedback: async ({ request }) => {
 		const data = await request.formData()
+
+		const spam = await checkNotSpam(data)
+		if (spam.drop) return { success: true }
+		if (spam.message) return fail(403, { message: spam.message })
+
+		const oversized = findOversizedField(data)
+		if (oversized) return fail(400, { message: oversized })
+
 		const name = getFormString(data, 'name') ?? 'Anonymous'
 		const email = getFormString(data, 'email') ?? ''
 		const subject = getFormString(data, 'subject')
 		const message = getFormString(data, 'message')
-		const nickname = getFormString(data, 'nickname')
-
-		if (nickname) {
-			return { success: true }
-		}
 
 		if (!subject || !message) {
 			return fail(400, { message: 'Missing required fields' })
+		}
+
+		// Email is optional here, but must look real if given.
+		if (email && !EMAIL_PATTERN.test(email)) {
+			return fail(400, { message: 'Please enter a valid email address.' })
 		}
 
 		const result = await sendContactEmail({

--- a/src/routes/contact-us/+page.svelte
+++ b/src/routes/contact-us/+page.svelte
@@ -6,7 +6,10 @@
 	import { onMount } from 'svelte'
 	import Link from '$lib/components/Link.svelte'
 	import PostMeta from '$lib/components/PostMeta.svelte'
+	import Turnstile from '$lib/components/Turnstile.svelte'
+	import { turnstileSiteKey } from '$lib/turnstile'
 	import { meta } from './meta'
+	import { partnershipOptions } from './partnership-options'
 	import type { ActionResult } from '@sveltejs/kit'
 
 	const { title, description } = meta
@@ -14,6 +17,15 @@
 	let activeTab: 'media' | 'partnerships' | 'feedback' = $state('partnerships')
 	let loading = $state(false)
 	let honeypot = $state('')
+	let turnstileToken = $state('')
+
+	// Bumped after each submission to remount the widget: Turnstile tokens are
+	// single-use, so a resubmit with the same token would be rejected.
+	let turnstileNonce = $state(0)
+
+	// Without a configured site key (e.g. local development) there is no widget
+	// to wait for, and the server decides whether to accept the submission.
+	const canSubmit = $derived(!loading && (!turnstileSiteKey || turnstileToken !== ''))
 
 	let formData = $state({
 		media: { name: '', email: '', subject: '', organization: '', details: '' },
@@ -34,29 +46,6 @@
 	function isRecord(value: unknown): value is Record<string, unknown> {
 		return typeof value === 'object' && value !== null
 	}
-
-	const partnershipOptions = [
-		'Mobilize grassroots support for PauseAI’s mission',
-		'Open a chapter in my city/country',
-		'Organize a public demonstration or protest',
-		'Support citizen lobbying efforts',
-		'Invite Pause AI to participate/speak at your local event/meeting',
-		'Test and refine policy proposals with policymakers',
-		'Amplify Pause AI campaign and/or proposal',
-		'Assist with surveys or qualitative data collection',
-		'Help disseminate research findings to the public',
-		'Connect Pause AI with experts',
-		'Share grassroots public sentiment data',
-		'Exchange volunteers for events or campaigns',
-		'Pool resources for joint campaigns or event',
-		'Collaborate on grant applications',
-		'Co-create educational or advocacy content',
-		'Mobilize volunteers for emergency response',
-		'Adapt messaging for local/international contexts',
-		'Connect with engaged volunteer base',
-		'Explore general partnership opportunities',
-		'Other'
-	]
 
 	function countWords(str: string) {
 		return str.trim().split(/\s+/).length
@@ -128,6 +117,11 @@
 		loading = true
 		return async ({ result, update }: { result: ActionResult; update: () => Promise<void> }) => {
 			loading = false
+
+			// The token has now been spent (or rejected) either way — get a fresh one.
+			turnstileToken = ''
+			turnstileNonce += 1
+
 			if (result.type === 'success') {
 				toast.success("Thank you! We've received your message.")
 
@@ -291,7 +285,10 @@
 							placeholder="Provide additional details to how you would like to partner with us, particularly if related to a time sensitive matter."
 							bind:value={formData.partnerships.message}></textarea>
 					</div>
-					<button type="submit" disabled={loading}>
+					{#key turnstileNonce}
+						<Turnstile bind:token={turnstileToken} />
+					{/key}
+					<button type="submit" disabled={!canSubmit}>
 						{loading ? 'Sending...' : 'Send Message'}
 					</button>
 				</form>
@@ -364,7 +361,10 @@
 							placeholder="Message"
 							bind:value={formData.media.details}></textarea>
 					</div>
-					<button type="submit" disabled={loading}>
+					{#key turnstileNonce}
+						<Turnstile bind:token={turnstileToken} />
+					{/key}
+					<button type="submit" disabled={!canSubmit}>
 						{loading ? 'Sending...' : 'Send Message'}
 					</button>
 				</form>
@@ -423,7 +423,10 @@
 							placeholder="Your Feedback"
 							bind:value={formData.feedback.message}></textarea>
 					</div>
-					<button type="submit" disabled={loading}>
+					{#key turnstileNonce}
+						<Turnstile bind:token={turnstileToken} />
+					{/key}
+					<button type="submit" disabled={!canSubmit}>
 						{loading ? 'Sending...' : 'Send Message'}
 					</button>
 				</form>

--- a/src/routes/contact-us/partnership-options.ts
+++ b/src/routes/contact-us/partnership-options.ts
@@ -1,0 +1,26 @@
+/**
+ * The options offered by the partnerships form's select.
+ * Shared with the server action so it can reject anything a bot invents.
+ */
+export const partnershipOptions: readonly string[] = [
+	'Mobilize grassroots support for PauseAI’s mission',
+	'Open a chapter in my city/country',
+	'Organize a public demonstration or protest',
+	'Support citizen lobbying efforts',
+	'Invite Pause AI to participate/speak at your local event/meeting',
+	'Test and refine policy proposals with policymakers',
+	'Amplify Pause AI campaign and/or proposal',
+	'Assist with surveys or qualitative data collection',
+	'Help disseminate research findings to the public',
+	'Connect Pause AI with experts',
+	'Share grassroots public sentiment data',
+	'Exchange volunteers for events or campaigns',
+	'Pool resources for joint campaigns or event',
+	'Collaborate on grant applications',
+	'Co-create educational or advocacy content',
+	'Mobilize volunteers for emergency response',
+	'Adapt messaging for local/international contexts',
+	'Connect with engaged volunteer base',
+	'Explore general partnership opportunities',
+	'Other'
+]

--- a/template.env
+++ b/template.env
@@ -9,6 +9,16 @@ AIRTABLE_API_KEY = ""
 # - [In "UK Politicians" base] Writing new emails to the "Web form emails" table which uses an Airtable automation to send the email.
 AIRTABLE_WRITE_API_KEY = ""
 
+# Cloudflare Turnstile — anti-spam on the /contact-us forms.
+# Optional locally: if TURNSTILE_SECRET_KEY is unset in development the check is
+# skipped (with a warning), but it is enforced in production.
+# To exercise the real flow locally, use Cloudflare's test keys:
+#   always passes: 1x00000000000000000000AA / 1x0000000000000000000000000000000AA
+#   always fails:  2x00000000000000000000AB / 2x0000000000000000000000000000000AA
+# Test site and secret keys only work when paired with each other.
+PUBLIC_TURNSTILE_SITE_KEY = ""
+TURNSTILE_SECRET_KEY = ""
+
 # Used for the /chat feature - optional for most local development
 OPENAI_KEY = ""
 # Used for the /write feature - optional for most local development

--- a/template.env
+++ b/template.env
@@ -12,10 +12,12 @@ AIRTABLE_WRITE_API_KEY = ""
 # Cloudflare Turnstile — anti-spam on the /contact-us forms.
 # Optional locally: if TURNSTILE_SECRET_KEY is unset in development the check is
 # skipped (with a warning), but it is enforced in production.
-# To exercise the real flow locally, use Cloudflare's test keys:
-#   always passes: 1x00000000000000000000AA / 1x0000000000000000000000000000000AA
-#   always fails:  2x00000000000000000000AB / 2x0000000000000000000000000000000AA
-# Test site and secret keys only work when paired with each other.
+# To exercise the real flow locally (including the rejection path), copy a pair of
+# always-passes / always-fails dummy keys from Cloudflare's docs:
+#   https://developers.cloudflare.com/turnstile/troubleshooting/testing/
+# Dummy site and secret keys only work when paired with each other.
+# Do not paste key values into this file — it is committed, and Netlify's secrets
+# scanning fails the build when a configured secret's value appears in repo files.
 PUBLIC_TURNSTILE_SITE_KEY = ""
 TURNSTILE_SECRET_KEY = ""
 


### PR DESCRIPTION
## Why

The `/contact-us` forms' only anti-spam measure was a hidden honeypot field ([#646](https://github.com/PauseAI/pauseai-website/pull/646)). That catches naive form-fillers, but does nothing about bots that POST directly to the form actions — a single `curl` with an `Origin` header reached partnerships@, press@ or feedback@ and also triggered an auto-reply to an attacker-supplied address, putting our MailerSend sending reputation at risk.

## What

- **Cloudflare Turnstile, verified server-side** before any email is sent. Fails closed if `TURNSTILE_SECRET_KEY` is missing, except under `dev`. Uses SvelteKit's compile-time `dev` rather than `isDev()`, so the check doesn't depend on which env vars the runtime exposes.
- **Deleted the `standard` action.** Its UI tab was removed in 0600d92d, so nothing legitimate could reach it — anything arriving there was a bot.
- **Escaped user input in the notification email.** It was interpolated raw, letting spammers inject live links into the team's inbox.
- **Server-side validation** of lengths, the 200-word message cap, email format, and the partnership-type select. These were browser-only hints before.

The honeypot stays — it's free and catches a different class of bot.

## Setup required

Two Netlify environment variables:

| Name | Notes |
|---|---|
| `PUBLIC_TURNSTILE_SITE_KEY` | Public. **Do not** mark as secret — it appears in build output and secrets scanning would fail the deploy. Read at build time, so it needs the Builds scope. |
| `TURNSTILE_SECRET_KEY` | Secret. Needs the Functions/Edge Functions scope. |

Leave `TURNSTILE_SECRET_KEY` unset for Deploy previews and Branch deploys so preview URLs fail closed rather than acting as an unprotected relay. `template.env` documents Cloudflare's test keys for local development.

## Verification

Tested against the dev server with Cloudflare's dummy keys:

| Case | Result |
|---|---|
| Direct POST with no token, all 3 tabs | 403, blocked |
| Always-fail secret with a well-formed token | 403, blocked |
| Valid token | passes gate, reaches MailerSend |
| Honeypot filled | silent fake success |
| `partnership_type` not in our list | 400 |
| Message >200 words / name >100 chars / malformed email | 400 |
| `?/standard` | 404 |

In the browser: the token enables submit, a failing key leaves submit disabled with an explanation, and tab switching leaves exactly one widget with no duplicates.

**Note:** `vite preview` doesn't surface `$env/dynamic/private` in this project, so the production-build path with a working secret couldn't be tested locally. The mechanism is the same one `MAILERSEND_API_KEY` already uses in production. Worth making one real submission after deploy to confirm.

## Limits

Turnstile stops automated submissions, not a human manually typing spam. If that starts, per-IP rate limiting would be next — awkward here because edge functions are stateless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)