### PR TITLE
Harden Turnstile against misconfiguration and token replay

### DIFF
--- a/src/routes/contact-us/+page.server.ts
+++ b/src/routes/contact-us/+page.server.ts
@@ -24,6 +24,14 @@ const mailerSendApiKey = env.MAILERSEND_API_KEY
 const TURNSTILE_VERIFY_URL = 'https://challenges.cloudflare.com/turnstile/v0/siteverify'
 
 /**
+ * Cloudflare's dummy test secrets (1x…/2x…/3x… followed by zeros), which pass or fail
+ * every token regardless of the challenge. Real secrets begin "0x".
+ * We reject the known-bad prefixes rather than requiring a known-good format, so a
+ * future change to Cloudflare's real key format cannot lock legitimate senders out.
+ */
+const TURNSTILE_TEST_SECRET = /^[123]x0{10}/
+
+/**
  * Maximum characters accepted per field. The client shows softer hints, but these
  * are the limits that count: bots POST straight to the action and never run our JS.
  */
@@ -46,7 +54,7 @@ type MailerSendError = {
 	message?: string
 }
 
-type TurnstileVerification = { success?: boolean; 'error-codes'?: unknown }
+type TurnstileVerification = { success?: boolean; hostname?: unknown; 'error-codes'?: unknown }
 
 function getFormString(formData: FormData, field: string): string | undefined {
 	const value = formData.get(field)
@@ -91,7 +99,8 @@ function findOversizedField(formData: FormData): string | undefined {
  * spam POSTs directly to the form action.
  */
 async function verifyTurnstile(
-	token: string | undefined
+	token: string | undefined,
+	expectedHostname: string
 ): Promise<{ ok: true } | { ok: false; message: string }> {
 	const secret = env.TURNSTILE_SECRET_KEY
 
@@ -112,6 +121,17 @@ async function verifyTurnstile(
 		}
 	}
 
+	// Fail closed on a *wrong* secret as well as a missing one. A test secret accepts
+	// every token, which would silently turn the form back into an open mail relay
+	// while every health check still looked green.
+	if (!dev && TURNSTILE_TEST_SECRET.test(secret)) {
+		console.error('TURNSTILE_SECRET_KEY is a Cloudflare test key — refusing it outside dev')
+		return {
+			ok: false,
+			message: 'Spam protection is misconfigured. Please email contact@pauseai.info instead.'
+		}
+	}
+
 	if (!token) {
 		return {
 			ok: false,
@@ -129,6 +149,19 @@ async function verifyTurnstile(
 		const result: unknown = await response.json()
 
 		if (isTurnstileVerification(result) && result.success === true) {
+			// Reject a token minted on another origin (a deploy preview, say) and replayed
+			// here. Only reject when Turnstile actually reports a different hostname — an
+			// absent or unexpected field must never lock out legitimate senders.
+			const hostname = typeof result.hostname === 'string' ? result.hostname : undefined
+			if (!dev && hostname && hostname !== expectedHostname) {
+				console.warn(
+					`Turnstile token was issued for ${hostname}, but submitted to ${expectedHostname}`
+				)
+				return {
+					ok: false,
+					message: 'The anti-spam check failed. Please reload the page and try again.'
+				}
+			}
 			return { ok: true }
 		}
 
@@ -313,22 +346,23 @@ async function sendConfirmationEmail(data: { name: string; email: string; type: 
  * `drop` means silently pretend success, so a bot does not learn it was caught.
  */
 async function checkNotSpam(
-	data: FormData
+	data: FormData,
+	expectedHostname: string
 ): Promise<{ drop: true } | { drop: false; message?: string }> {
 	// Hidden field that only an automated form-filler completes.
 	if (getFormString(data, 'nickname')) return { drop: true }
 
-	const verification = await verifyTurnstile(getFormString(data, TURNSTILE_FIELD))
+	const verification = await verifyTurnstile(getFormString(data, TURNSTILE_FIELD), expectedHostname)
 	if (!verification.ok) return { drop: false, message: verification.message }
 
 	return { drop: false }
 }
 
 export const actions: Actions = {
-	media: async ({ request }) => {
+	media: async ({ request, url }) => {
 		const data = await request.formData()
 
-		const spam = await checkNotSpam(data)
+		const spam = await checkNotSpam(data, url.hostname)
 		if (spam.drop) return { success: true }
 		if (spam.message) return fail(403, { message: spam.message })
 
@@ -366,10 +400,10 @@ export const actions: Actions = {
 
 		return { success: true }
 	},
-	partnerships: async ({ request }) => {
+	partnerships: async ({ request, url }) => {
 		const data = await request.formData()
 
-		const spam = await checkNotSpam(data)
+		const spam = await checkNotSpam(data, url.hostname)
 		if (spam.drop) return { success: true }
 		if (spam.message) return fail(403, { message: spam.message })
 
@@ -431,10 +465,10 @@ export const actions: Actions = {
 
 		return { success: true }
 	},
-	feedback: async ({ request }) => {
+	feedback: async ({ request, url }) => {
 		const data = await request.formData()
 
-		const spam = await checkNotSpam(data)
+		const spam = await checkNotSpam(data, url.hostname)
 		if (spam.drop) return { success: true }
 		if (spam.message) return fail(403, { message: spam.message })
 


### PR DESCRIPTION
Follow-up to [#1036](https://github.com/PauseAI/pauseai-website/pull/1036).

## Why

#1036 fails closed when `TURNSTILE_SECRET_KEY` is **missing**, but not when it is **wrong**. Cloudflare's test secrets validate any token at all, so setting one in production would silently restore an open mail relay while every health check still looked green.

That isn't hypothetical — it is the state our deploy-preview context was in. A submission carrying the literal token `obviously-not-valid` was accepted there and sent real mail.

## What

**1. Refuse Cloudflare's dummy test secrets outside `dev`.** Their secrets start `1x`/`2x`/`3x` followed by zeros; real ones start `0x`. We reject the known-bad prefixes rather than requiring a known-good format, so a future change to Cloudflare's real key format cannot lock legitimate senders out of the form.

**2. Check the hostname `siteverify` reports** against the host the form was actually submitted to, so a token minted on another origin (a deploy preview, say) cannot be replayed against production. The expected host is derived from the request rather than hardcoded, so it works across production, previews and localhost with no config.

Deliberately conservative: only an **explicitly mismatching** hostname rejects. An absent or unexpected `hostname` field is allowed through, so an unforeseen response shape can never break the contact form.

Neither check applies under `dev`, so local development with Cloudflare's test keys still works.

## Verification

- Regex checked against all three Cloudflare test secrets (matched), a realistic real secret starting `0x` (not matched), a site test key pasted by mistake (matched), and empty (not matched).
- Confirmed both guards survive into the emitted production server bundle, i.e. `!dev` did not compile them away, while the dev-only bypass is correctly eliminated.
- Confirmed local dev is unaffected: a valid dummy token still passes the gate, and a tokenless POST is still rejected 403.
- `pnpm check` 0 errors, `pnpm lint` 0 errors, production build succeeds.

The one path I could not exercise locally is a production build with a populated secret — `vite preview` does not surface `$env/dynamic/private` in this project, which is why the checks above are static and dev-side. The runtime mechanism itself is already proven: #1036's gate was confirmed working against the real Netlify edge deployment.

## Related operational follow-up

Independent of this PR, `TURNSTILE_SECRET_KEY` should be cleared from the **Deploy previews**, **Branch deploys** and **Preview servers** contexts. Those currently hold an always-pass test key, so preview URLs remain usable as a relay — and with this PR merged they would additionally start refusing submissions outright, which is the safe outcome but worth knowing about.

🤖 Generated with [Claude Code](https://claude.com/claude-code)