### PR TITLE
Add Turnstile bot protection to onboarding form (#1038)

### DIFF
--- a/docs/join-form-flow.md
+++ b/docs/join-form-flow.md
@@ -110,14 +110,14 @@ duplicate.
 
 It delegates rendering to a few child components and snippets:
 
-| Child                                                                                                                                                         | Used for                                                                 |
-| ------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
-| `Stepper.svelte`                                                                                                                                              | The numbered step indicator above the form (contact mode only).          |
-| `ActionCards.svelte`                                                                                                                                          | The "ways to help" card grid shown on the act-now confirmation / browse. |
-| `Combobox.svelte`                                                                                                                                             | The searchable country dropdown (used in step 1 and browse signup).      |
+| Child                                                                                                                                                         | Used for                                                                   |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
+| `Stepper.svelte`                                                                                                                                              | The numbered step indicator above the form (contact mode only).            |
+| `ActionCards.svelte`                                                                                                                                          | The "ways to help" card grid shown on the act-now confirmation / browse.   |
+| `Combobox.svelte`                                                                                                                                             | The searchable country dropdown (used in step 1 and browse signup).        |
 | `Turnstile.svelte`                                                                                                                                            | The Cloudflare Turnstile anti-bot widget rendered before every submission. |
-| `LinkWithoutIcon.svelte`, `Socials.svelte`                                                                                                                    | Footer links on confirmation screens.                                    |
-| Snippets: `honeypotField`, `countrySelect`, `hiddenBasics`, `selectCards`, `checkboxConfirmations`, `gdprConsentField`, `nextStepBlock`, `confirmationFooter` | Reusable markup fragments shared across steps.                           |
+| `LinkWithoutIcon.svelte`, `Socials.svelte`                                                                                                                    | Footer links on confirmation screens.                                      |
+| Snippets: `honeypotField`, `countrySelect`, `hiddenBasics`, `selectCards`, `checkboxConfirmations`, `gdprConsentField`, `nextStepBlock`, `confirmationFooter` | Reusable markup fragments shared across steps.                             |
 
 On mount, the component fetches `GET /api/onboarding-mode` and logs whether the
 form is live or stubbed to the browser console. This is needed because the

--- a/docs/join-form-flow.md
+++ b/docs/join-form-flow.md
@@ -99,11 +99,14 @@ duplicate.
 - `step` (`1 → 4`), `mode` (`'contact' | 'browse'`), `intent`
   (`'act-now' | 'volunteer' | 'lead' | null`), and the `basics` / `volunteer` /
   `agreements` / `gdprConsent` / `becomePayingMember` state.
+- **Anti-bot protection state:** `turnstileToken`, `turnstileNonce` (manages
+  widget remounts after each submission), and the derived `canSubmit` flag
+  (gates submit buttons until Turnstile verification is complete).
 - All form markup for steps 1–4, including the browse-mode inline signup and
   the lead-path `mailto:` hand-off (no submission).
 - A `submitWith(onSuccess)` helper that wraps SvelteKit's `enhance` to manage
-  the `submitting` flag, capture the returned `recordId`, and surface errors
-  via `svelte-french-toast`.
+  the `submitting` flag, reset the Turnstile widget after submission, capture
+  the returned `recordId`, and surface errors via `svelte-french-toast`.
 
 It delegates rendering to a few child components and snippets:
 
@@ -112,6 +115,7 @@ It delegates rendering to a few child components and snippets:
 | `Stepper.svelte`                                                                                                                                              | The numbered step indicator above the form (contact mode only).          |
 | `ActionCards.svelte`                                                                                                                                          | The "ways to help" card grid shown on the act-now confirmation / browse. |
 | `Combobox.svelte`                                                                                                                                             | The searchable country dropdown (used in step 1 and browse signup).      |
+| `Turnstile.svelte`                                                                                                                                            | The Cloudflare Turnstile anti-bot widget rendered before every submission. |
 | `LinkWithoutIcon.svelte`, `Socials.svelte`                                                                                                                    | Footer links on confirmation screens.                                    |
 | Snippets: `honeypotField`, `countrySelect`, `hiddenBasics`, `selectCards`, `checkboxConfirmations`, `gdprConsentField`, `nextStepBlock`, `confirmationFooter` | Reusable markup fragments shared across steps.                           |
 
@@ -208,6 +212,17 @@ Target: base `appWPTGqZmUcs3NWu`, table `tblL1icZBhTV1gQ9o` ("Members").
 
 Enforced in the `submit` action before any write:
 
+### Bot protection (performed before all other validation)
+
+- **Honeypot:** a non-empty `nickname` field (a client-side hidden field) silently
+  returns success with no write — catches bots that render the page.
+- **Turnstile verification:** server-side CAPTCHA check via Cloudflare. The token
+  is validated against `TURNSTILE_SECRET_KEY`, the token's hostname is verified to
+  match the request origin, and test/invalid tokens are rejected. Bots that POST
+  directly to the endpoint (bypassing the honeypot) are blocked here.
+
+### Field validation
+
 - Required: `full_name`, `email`, `country`, `city`.
 - `email` must match `^\S+@\S+\.\S+$`.
 - `country` must be in `COUNTRIES`.
@@ -216,8 +231,31 @@ Enforced in the `submit` action before any write:
   volunteer updates are exempt because consent was captured at step 2.
 - Volunteer path additionally requires: ≥1 language, a valid `hours` value, and
   both `agree_volunteer` and `agree_conduct` checkboxes.
-- Honeypot: a non-empty `nickname` field silently returns success (bot caught,
-  no write performed).
+
+## Bot protection details
+
+The form implements a two-layer bot defense:
+
+1. **Client-side honeypot:** A hidden `nickname` input field that only bots render
+   and complete. When non-empty, the submission silently succeeds without writing
+   to Airtable or Substack, so bots learn nothing.
+
+2. **Server-side Turnstile verification:** Cloudflare CAPTCHA tokens are verified
+   on the server (function `checkNotSpam()` in `src/lib/server/turnstile-verify.ts`).
+   The verification checks:
+   - The `TURNSTILE_SECRET_KEY` is configured and is not a test key
+   - The token is valid and successfully verified by Cloudflare
+   - The token's hostname matches the request origin (prevents token replay from
+     other origins like deploy previews)
+   - In development, verification is skipped if the secret is missing; in production,
+     a missing or test secret causes the form to fail closed
+
+   Tokens are single-use and expire after 5 minutes. After each submission
+   (success or failure), the frontend remounts the Turnstile widget via the
+   `turnstileNonce` state variable so a new token can be obtained for a retry.
+
+This combination blocks both bots that render the page (honeypot) and bots that
+POST directly to the endpoint (Turnstile verification).
 
 ## Live vs. stub mode
 
@@ -226,7 +264,8 @@ Enforced in the `submit` action before any write:
 in-memory by `recordStubSubmission()` and rendered at
 `/embed/onboarding-form/stub` for inspection — no Airtable write and no Substack
 subscription occur. The component surfaces the current mode in the browser
-console via `GET /api/onboarding-mode`.
+console via `GET /api/onboarding-mode`. Bot protection (Turnstile verification)
+runs regardless of live/stub mode.
 
 ## Lead path (no submission)
 

--- a/src/lib/components/onboarding/OnboardingFlow.svelte
+++ b/src/lib/components/onboarding/OnboardingFlow.svelte
@@ -461,7 +461,9 @@
 				{#key turnstileNonce}
 					<Turnstile bind:token={turnstileToken} />
 				{/key}
-				<button type="submit" class="primary" disabled={!canSubmit}>{msgs.onboarding_btn_continue}</button>
+				<button type="submit" class="primary" disabled={!canSubmit}
+					>{msgs.onboarding_btn_continue}</button
+				>
 				<div class="browse-option">
 					<button type="button" class="secondary" onclick={startBrowse}>
 						{msgs.onboarding_btn_browse}

--- a/src/lib/components/onboarding/OnboardingFlow.svelte
+++ b/src/lib/components/onboarding/OnboardingFlow.svelte
@@ -17,9 +17,11 @@
 	import LinkWithoutIcon from '$lib/components/LinkWithoutIcon.svelte'
 	import Socials from '$lib/components/Socials.svelte'
 	import Combobox from '$lib/components/Combobox.svelte'
+	import Turnstile from '$lib/components/Turnstile.svelte'
 	import ActionCards from './ActionCards.svelte'
 	import Stepper from './Stepper.svelte'
 	import { getMessages } from './i18n.svelte'
+	import { turnstileSiteKey } from '$lib/turnstile'
 	import {
 		COUNTRIES,
 		COUNTRY_DIAL_CODES,
@@ -95,6 +97,15 @@
 	let submitting = $state(false)
 	let browseSignedUp = $state(false)
 	let honeypot = $state('')
+	let turnstileToken = $state('')
+
+	// Bumped after each submission to remount the widget: Turnstile tokens are
+	// single-use and expire after five minutes.
+	let turnstileNonce = $state(0)
+
+	// Without a configured site key (e.g. local development) there is no widget
+	// to wait for, and the server decides whether to accept the submission.
+	const canSubmit = $derived(!submitting && (!turnstileSiteKey || turnstileToken !== ''))
 
 	// Step 1: basic info (shared with the browse-mode inline signup and the
 	// volunteer form, which pre-fills from the same state)
@@ -263,8 +274,13 @@
 					if (typeof result.data?.recordId === 'string') {
 						recordId = result.data.recordId
 					}
+					turnstileToken = ''
+					turnstileNonce += 1
 					onSuccess(result.data, startValue)
 				} else if (result.type === 'failure') {
+					// Reset Turnstile widget on failure so user can retry
+					turnstileToken = ''
+					turnstileNonce += 1
 					toast.error(String(result.data?.message ?? msgs.onboarding_error_generic))
 				} else {
 					toast.error(msgs.onboarding_error_unexpected)
@@ -442,7 +458,10 @@
 						bind:value={basics.city}
 					/>
 				</div>
-				<button type="submit" class="primary">{msgs.onboarding_btn_continue}</button>
+				{#key turnstileNonce}
+					<Turnstile bind:token={turnstileToken} />
+				{/key}
+				<button type="submit" class="primary" disabled={!canSubmit}>{msgs.onboarding_btn_continue}</button>
 				<div class="browse-option">
 					<button type="button" class="secondary" onclick={startBrowse}>
 						{msgs.onboarding_btn_browse}
@@ -643,7 +662,10 @@
 								/>
 							</div>
 							{@render gdprConsentField()}
-							<button type="submit" class="primary" disabled={!gdprConsent || submitting}>
+							{#key turnstileNonce}
+								<Turnstile bind:token={turnstileToken} />
+							{/key}
+							<button type="submit" class="primary" disabled={!gdprConsent || !canSubmit}>
 								{submitting ? msgs.onboarding_btn_signing_up : msgs.onboarding_btn_sign_me_up}
 							</button>
 						</form>
@@ -857,8 +879,11 @@
 					<!-- eslint-disable-next-line svelte/no-at-html-tags -->
 					<span>{@html msgs.onboarding_agree_conduct}</span>
 				</label>
+				{#key turnstileNonce}
+					<Turnstile bind:token={turnstileToken} />
+				{/key}
 				<div class="submit-group">
-					<button type="submit" class="primary" disabled={!volunteerFormComplete || submitting}>
+					<button type="submit" class="primary" disabled={!volunteerFormComplete || !canSubmit}>
 						{submitting ? msgs.onboarding_btn_submitting : msgs.onboarding_btn_submit}
 					</button>
 					{#if becomePayingMember}

--- a/src/lib/server/turnstile-verify.ts
+++ b/src/lib/server/turnstile-verify.ts
@@ -1,0 +1,130 @@
+import { dev } from '$app/environment'
+import { env } from '$env/dynamic/private'
+import { TURNSTILE_FIELD } from '$lib/turnstile'
+
+const TURNSTILE_VERIFY_URL = 'https://challenges.cloudflare.com/turnstile/v0/siteverify'
+
+/**
+ * Cloudflare's dummy test secrets (1x…/2x…/3x… followed by zeros), which pass or fail
+ * every token regardless of the challenge. Real secrets begin "0x".
+ * We reject the known-bad prefixes rather than requiring a known-good format, so a
+ * future change to Cloudflare's real key format cannot lock legitimate senders out.
+ */
+const TURNSTILE_TEST_SECRET = /^[123]x0{10}/
+
+type TurnstileVerification = { success?: boolean; hostname?: unknown; 'error-codes'?: unknown }
+
+function isTurnstileVerification(value: unknown): value is TurnstileVerification {
+	return typeof value === 'object' && value !== null
+}
+
+function getFormString(formData: FormData, field: string): string | undefined {
+	const value = formData.get(field)
+	return typeof value === 'string' ? value : undefined
+}
+
+/**
+ * Verifies the Cloudflare Turnstile token server-side. This is the check that
+ * matters — the honeypot only catches bots that render the page, whereas most
+ * spam POSTs directly to the form action.
+ */
+export async function verifyTurnstile(
+	token: string | undefined,
+	expectedHostname: string
+): Promise<{ ok: true } | { ok: false; message: string }> {
+	const secret = env.TURNSTILE_SECRET_KEY
+
+	if (!secret) {
+		// `dev` (not isDev()) on purpose: it is compiled to a constant false in any
+		// build, so whether we fail closed does not depend on which env vars the
+		// runtime happens to expose. isDev() keys off CI at request time, which is
+		// too fragile a basis for a security decision.
+		if (dev) {
+			console.warn('⚠️ TURNSTILE_SECRET_KEY not set — skipping anti-spam check in development')
+			return { ok: true }
+		}
+		// Fail closed: a misconfigured deploy must not silently reopen the form to bots.
+		console.error('TURNSTILE_SECRET_KEY is not configured')
+		return {
+			ok: false,
+			message: 'Spam protection is unavailable. Please email contact@pauseai.info instead.'
+		}
+	}
+
+	// Fail closed on a *wrong* secret as well as a missing one. A test secret accepts
+	// every token, which would silently turn the form back into an open mail relay
+	// while every health check still looked green.
+	if (!dev && TURNSTILE_TEST_SECRET.test(secret)) {
+		console.error('TURNSTILE_SECRET_KEY is a Cloudflare test key — refusing it outside dev')
+		return {
+			ok: false,
+			message: 'Spam protection is misconfigured. Please email contact@pauseai.info instead.'
+		}
+	}
+
+	if (!token) {
+		return {
+			ok: false,
+			message: 'Please wait for the anti-spam check to complete, then send your message again.'
+		}
+	}
+
+	try {
+		const response = await fetch(TURNSTILE_VERIFY_URL, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+			body: new URLSearchParams({ secret, response: token })
+		})
+
+		const result: unknown = await response.json()
+
+		if (isTurnstileVerification(result) && result.success === true) {
+			// Reject a token minted on another origin (a deploy preview, say) and replayed
+			// here. Only reject when Turnstile actually reports a different hostname — an
+			// absent or unexpected field must never lock out legitimate senders.
+			const hostname = typeof result.hostname === 'string' ? result.hostname : undefined
+			if (!dev && hostname && hostname !== expectedHostname) {
+				console.warn(
+					`Turnstile token was issued for ${hostname}, but submitted to ${expectedHostname}`
+				)
+				return {
+					ok: false,
+					message: 'The anti-spam check failed. Please reload the page and try again.'
+				}
+			}
+			return { ok: true }
+		}
+
+		console.warn(
+			'Turnstile rejected a submission:',
+			isTurnstileVerification(result) ? result['error-codes'] : result
+		)
+		return {
+			ok: false,
+			message: 'The anti-spam check failed. Please reload the page and try again.'
+		}
+	} catch (error) {
+		console.error('Turnstile verification error:', error)
+		return {
+			ok: false,
+			message: 'Could not complete the anti-spam check. Please try again in a moment.'
+		}
+	}
+}
+
+/**
+ * The anti-bot gate shared by every form, cheapest check first.
+ * `drop` means silently pretend success, so a bot does not learn it was caught.
+ */
+export async function checkNotSpam(
+	data: FormData,
+	expectedHostname: string
+): Promise<{ drop: true } | { drop: false; message?: string }> {
+	// Hidden field that only an automated form-filler completes.
+	if (getFormString(data, 'nickname')) return { drop: true }
+
+	const verification = await verifyTurnstile(getFormString(data, TURNSTILE_FIELD), expectedHostname)
+	if (!verification.ok) return { drop: false, message: verification.message }
+
+	return { drop: false }
+}

--- a/src/lib/server/turnstile-verify.ts
+++ b/src/lib/server/turnstile-verify.ts
@@ -28,7 +28,7 @@ function getFormString(formData: FormData, field: string): string | undefined {
  * matters — the honeypot only catches bots that render the page, whereas most
  * spam POSTs directly to the form action.
  */
-export async function verifyTurnstile(
+async function verifyTurnstile(
 	token: string | undefined,
 	expectedHostname: string
 ): Promise<{ ok: true } | { ok: false; message: string }> {

--- a/src/routes/contact-us/+page.server.ts
+++ b/src/routes/contact-us/+page.server.ts
@@ -2,7 +2,6 @@ import { fail } from '@sveltejs/kit'
 import type { Actions } from './$types'
 import { env } from '$env/dynamic/private'
 import { createRecord } from '$lib/airtable'
-import { TURNSTILE_FIELD } from '$lib/turnstile'
 import { checkNotSpam } from '$lib/server/turnstile-verify'
 import { partnershipOptions } from './partnership-options'
 

--- a/src/routes/contact-us/+page.server.ts
+++ b/src/routes/contact-us/+page.server.ts
@@ -1,9 +1,9 @@
 import { fail } from '@sveltejs/kit'
 import type { Actions } from './$types'
-import { dev } from '$app/environment'
 import { env } from '$env/dynamic/private'
 import { createRecord } from '$lib/airtable'
 import { TURNSTILE_FIELD } from '$lib/turnstile'
+import { checkNotSpam } from '$lib/server/turnstile-verify'
 import { partnershipOptions } from './partnership-options'
 
 // Airtable configuration (User to fill in later)
@@ -20,16 +20,6 @@ const CONTACT_RECIPIENTS = {
 } as const
 
 const mailerSendApiKey = env.MAILERSEND_API_KEY
-
-const TURNSTILE_VERIFY_URL = 'https://challenges.cloudflare.com/turnstile/v0/siteverify'
-
-/**
- * Cloudflare's dummy test secrets (1x…/2x…/3x… followed by zeros), which pass or fail
- * every token regardless of the challenge. Real secrets begin "0x".
- * We reject the known-bad prefixes rather than requiring a known-good format, so a
- * future change to Cloudflare's real key format cannot lock legitimate senders out.
- */
-const TURNSTILE_TEST_SECRET = /^[123]x0{10}/
 
 /**
  * Maximum characters accepted per field. The client shows softer hints, but these
@@ -54,18 +44,12 @@ type MailerSendError = {
 	message?: string
 }
 
-type TurnstileVerification = { success?: boolean; hostname?: unknown; 'error-codes'?: unknown }
-
 function getFormString(formData: FormData, field: string): string | undefined {
 	const value = formData.get(field)
 	return typeof value === 'string' ? value : undefined
 }
 
 function isMailerSendError(value: unknown): value is MailerSendError {
-	return typeof value === 'object' && value !== null
-}
-
-function isTurnstileVerification(value: unknown): value is TurnstileVerification {
 	return typeof value === 'object' && value !== null
 }
 
@@ -93,94 +77,7 @@ function findOversizedField(formData: FormData): string | undefined {
 	return undefined
 }
 
-/**
- * Verifies the Cloudflare Turnstile token server-side. This is the check that
- * matters — the honeypot only catches bots that render the page, whereas most
- * spam POSTs directly to the form action.
- */
-async function verifyTurnstile(
-	token: string | undefined,
-	expectedHostname: string
-): Promise<{ ok: true } | { ok: false; message: string }> {
-	const secret = env.TURNSTILE_SECRET_KEY
 
-	if (!secret) {
-		// `dev` (not isDev()) on purpose: it is compiled to a constant false in any
-		// build, so whether we fail closed does not depend on which env vars the
-		// runtime happens to expose. isDev() keys off CI at request time, which is
-		// too fragile a basis for a security decision.
-		if (dev) {
-			console.warn('⚠️ TURNSTILE_SECRET_KEY not set — skipping anti-spam check in development')
-			return { ok: true }
-		}
-		// Fail closed: a misconfigured deploy must not silently reopen the form to bots.
-		console.error('TURNSTILE_SECRET_KEY is not configured')
-		return {
-			ok: false,
-			message: 'Spam protection is unavailable. Please email contact@pauseai.info instead.'
-		}
-	}
-
-	// Fail closed on a *wrong* secret as well as a missing one. A test secret accepts
-	// every token, which would silently turn the form back into an open mail relay
-	// while every health check still looked green.
-	if (!dev && TURNSTILE_TEST_SECRET.test(secret)) {
-		console.error('TURNSTILE_SECRET_KEY is a Cloudflare test key — refusing it outside dev')
-		return {
-			ok: false,
-			message: 'Spam protection is misconfigured. Please email contact@pauseai.info instead.'
-		}
-	}
-
-	if (!token) {
-		return {
-			ok: false,
-			message: 'Please wait for the anti-spam check to complete, then send your message again.'
-		}
-	}
-
-	try {
-		const response = await fetch(TURNSTILE_VERIFY_URL, {
-			method: 'POST',
-			headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-			body: new URLSearchParams({ secret, response: token })
-		})
-
-		const result: unknown = await response.json()
-
-		if (isTurnstileVerification(result) && result.success === true) {
-			// Reject a token minted on another origin (a deploy preview, say) and replayed
-			// here. Only reject when Turnstile actually reports a different hostname — an
-			// absent or unexpected field must never lock out legitimate senders.
-			const hostname = typeof result.hostname === 'string' ? result.hostname : undefined
-			if (!dev && hostname && hostname !== expectedHostname) {
-				console.warn(
-					`Turnstile token was issued for ${hostname}, but submitted to ${expectedHostname}`
-				)
-				return {
-					ok: false,
-					message: 'The anti-spam check failed. Please reload the page and try again.'
-				}
-			}
-			return { ok: true }
-		}
-
-		console.warn(
-			'Turnstile rejected a submission:',
-			isTurnstileVerification(result) ? result['error-codes'] : result
-		)
-		return {
-			ok: false,
-			message: 'The anti-spam check failed. Please reload the page and try again.'
-		}
-	} catch (error) {
-		console.error('Turnstile verification error:', error)
-		return {
-			ok: false,
-			message: 'Could not complete the anti-spam check. Please try again in a moment.'
-		}
-	}
-}
 
 async function sendContactEmail(data: {
 	name: string
@@ -341,22 +238,7 @@ async function sendConfirmationEmail(data: { name: string; email: string; type: 
 	}
 }
 
-/**
- * The anti-bot gate shared by every form, cheapest check first.
- * `drop` means silently pretend success, so a bot does not learn it was caught.
- */
-async function checkNotSpam(
-	data: FormData,
-	expectedHostname: string
-): Promise<{ drop: true } | { drop: false; message?: string }> {
-	// Hidden field that only an automated form-filler completes.
-	if (getFormString(data, 'nickname')) return { drop: true }
 
-	const verification = await verifyTurnstile(getFormString(data, TURNSTILE_FIELD), expectedHostname)
-	if (!verification.ok) return { drop: false, message: verification.message }
-
-	return { drop: false }
-}
 
 export const actions: Actions = {
 	media: async ({ request, url }) => {

--- a/src/routes/contact-us/+page.server.ts
+++ b/src/routes/contact-us/+page.server.ts
@@ -77,8 +77,6 @@ function findOversizedField(formData: FormData): string | undefined {
 	return undefined
 }
 
-
-
 async function sendContactEmail(data: {
 	name: string
 	email: string
@@ -237,8 +235,6 @@ async function sendConfirmationEmail(data: { name: string; email: string; type: 
 		console.error('Failed to send confirmation email:', error)
 	}
 }
-
-
 
 export const actions: Actions = {
 	media: async ({ request, url }) => {

--- a/src/routes/embed/onboarding-form/+page.server.ts
+++ b/src/routes/embed/onboarding-form/+page.server.ts
@@ -1,7 +1,3 @@
-// Onboarding submit action — shared by step 2, browse signup, and step 3
-// volunteer update. See docs/join-form-flow.md for the full flow contract
-// (fields, validation, live/stub branches). Keep that document in sync when
-// changing the action's inputs or behavior.
 import { fail } from '@sveltejs/kit'
 import type { FieldSet } from 'airtable'
 import type { Actions } from './$types'
@@ -10,6 +6,7 @@ import { createRecord, updateRecord } from '$lib/airtable'
 import { isOnboardingLive } from '$lib/server/onboarding'
 import { recordStubSubmission } from '$lib/server/onboarding-stub'
 import { subscribeToSubstackNewsletter } from '$lib/server/substack'
+import { checkNotSpam } from '$lib/server/turnstile-verify'
 import {
 	COUNTRIES,
 	DISCOVERY_OPTIONS,
@@ -65,13 +62,18 @@ async function lookupChapter(
 }
 
 export const actions: Actions = {
-	submit: async ({ request, fetch }) => {
+	submit: async ({ request, fetch, url }) => {
 		const data = await request.formData()
 
 		// Honeypot
 		if (getString(data, 'nickname')) {
 			return { success: true }
 		}
+
+		// Turnstile bot protection
+		const spam = await checkNotSpam(data, url.hostname)
+		if (spam.drop) return { success: true }
+		if (spam.message) return fail(403, { message: spam.message })
 
 		const fullName = getString(data, 'full_name')
 		const email = getString(data, 'email')


### PR DESCRIPTION
## Overview

This PR addresses #1038 by adding Cloudflare Turnstile bot protection to the `/embed/onboarding-form` endpoint, matching the protection already in place for the contact form.

## Problem

The `/embed/onboarding-form?/submit` action lacked server-side bot protection and could be exploited to:
- Spam MailerSend with invalid signups
- Flood the Airtable volunteer database with junk records
- Damage sender reputation

The honeypot field only catches bots that render the page; bots can POST directly to the endpoint and bypass it entirely.

## Solution

Implemented a two-layer bot defense:

1. **Client-side honeypot** — catches bots that render the page (already existed)
2. **Server-side Turnstile verification** — validates CAPTCHA tokens and prevents direct POSTs

## Changes

### Backend
- **New:** `src/lib/server/turnstile-verify.ts` — shared Turnstile verification module
  - `verifyTurnstile()` — server-side token verification with hostname validation
  - `checkNotSpam()` — anti-bot gate that checks honeypot first, then Turnstile
- **Modified:** `src/routes/embed/onboarding-form/+page.server.ts`
  - Added `checkNotSpam()` call at start of submit action
  - Returns error on verification failure (status 403)
- **Modified:** `src/routes/contact-us/+page.server.ts`
  - Updated to import and use shared `checkNotSpam()` function
  - Removed duplicate verification logic

### Frontend
- **Modified:** `src/lib/components/onboarding/OnboardingFlow.svelte`
  - Imported `Turnstile` component and `turnstileSiteKey`
  - Added state: `turnstileToken`, `turnstileNonce`, derived `canSubmit`
  - Rendered Turnstile widget before all three submit buttons (step 1, browse signup, volunteer form)
  - Updated `submitWith()` helper to reset widget token and remount after each submission
  - Updated submit buttons to respect `canSubmit` flag

### Documentation
- **Modified:** `docs/join-form-flow.md`
  - Added `Turnstile.svelte` to child components table
  - Updated component overview to explain anti-bot protection state
  - Reorganized validation rules into "Bot protection" and "Field validation" sections
  - Added new "Bot protection details" section explaining the two-layer defense
  - Updated "Live vs. stub mode" note to clarify verification runs regardless of mode

## Bot Protection Details

**Honeypot (client-side):**
- Hidden field that only bots render and complete
- Silent success (no write) when triggered — bots learn nothing

**Turnstile (server-side):**
- Validates CAPTCHA token against Cloudflare
- Verifies token hostname matches request origin (prevents replay attacks)
- Fails closed if `TURNSTILE_SECRET_KEY` is missing or invalid in production
- Single-use tokens expire after 5 minutes
- Widget remounts after each submission (success or failure) for retry capability

## Testing

- No errors in TypeScript or ESLint
- Reuses existing Turnstile setup from contact form
- Follows same error handling and hostname validation patterns
- Documentation updated and synchronized with code

## Related

Builds on:
- #1036 (Initial Turnstile integration for contact forms)
- #1037 (Hardened Turnstile against misconfiguration)