### PR TITLE
Move Turnstile widget from step 1 to step 2 of onboarding flow

### DIFF
--- a/src/lib/components/onboarding/OnboardingFlow.svelte
+++ b/src/lib/components/onboarding/OnboardingFlow.svelte
@@ -458,12 +458,7 @@
 						bind:value={basics.city}
 					/>
 				</div>
-				{#key turnstileNonce}
-					<Turnstile bind:token={turnstileToken} />
-				{/key}
-				<button type="submit" class="primary" disabled={!canSubmit}
-					>{msgs.onboarding_btn_continue}</button
-				>
+				<button type="submit" class="primary">{msgs.onboarding_btn_continue}</button>
 				<div class="browse-option">
 					<button type="button" class="secondary" onclick={startBrowse}>
 						{msgs.onboarding_btn_browse}
@@ -561,10 +556,13 @@
 					{/each}
 				</div>
 				{@render gdprConsentField()}
+				{#key turnstileNonce}
+					<Turnstile bind:token={turnstileToken} />
+				{/key}
 				<button
 					type="submit"
 					class="primary"
-					disabled={(!intent && !keepInformed && !basics.newsletter) || !gdprConsent || submitting}
+					disabled={(!intent && !keepInformed && !basics.newsletter) || !gdprConsent || !canSubmit}
 				>
 					{submitting
 						? msgs.onboarding_btn_submitting


### PR DESCRIPTION
## Problem

Submitting step 2 of the onboarding flow failed with *"Please wait for the anti-spam check to complete, then send your message again"*, even though no Turnstile widget was visible on the step.

## Root cause

The Turnstile widget added in #1039 was placed on **step 1** of the onboarding flow. Step 1's form uses a client-side `onsubmit={continueToIntent}` handler that never POSTs to the server — it just advances `step` to 2 — so the captured token was discarded the moment the user moved on.

**Step 2** is the first form that actually POSTs to `/embed/onboarding-form?/submit`, which runs `verifyTurnstile`. Because step 2 had no `<Turnstile>` component, no `turnstile_token` field was ever submitted, and the server always received `token === undefined`, returning the "wait for the anti-spam check" error.

## Fix

Move the `<Turnstile>` component (and its `{#key turnstileNonce}` remount wrapper) from step 1 to step 2, placing it after the GDPR consent field. Also gate step 2's submit button on `canSubmit` so the user can't submit before the token is ready, matching the pattern already used on the browse-signup and volunteer forms. Step 1's button no longer needs the `canSubmit` gate since it doesn't submit to the server.

Follow-up to #1039.