### PR TITLE
Don't let the anti-spam check block deploy previews

### DIFF
--- a/docs/join-form-flow.md
+++ b/docs/join-form-flow.md
@@ -264,8 +264,19 @@ POST directly to the endpoint (Turnstile verification).
 in-memory by `recordStubSubmission()` and rendered at
 `/embed/onboarding-form/stub` for inspection — no Airtable write and no Substack
 subscription occur. The component surfaces the current mode in the browser
-console via `GET /api/onboarding-mode`. Bot protection (Turnstile verification)
-runs regardless of live/stub mode.
+console via `GET /api/onboarding-mode`.
+
+Bot protection follows the same switch. The honeypot runs on every submission,
+but Turnstile verification runs only in live mode: in stub mode there is no
+record, no subscription and no mail to protect, and requiring it would make the
+form untestable on deploy previews, whose hostname the Turnstile site key does
+not allow (the widget refuses to render, so no token can exist). The client
+mirrors this, and assumes live until `/api/onboarding-mode` says otherwise.
+
+`ONBOARDING_LIVE=true` therefore has to be scoped to the **Production** context
+in Netlify. Set site-wide it would also make deploy previews live, which both
+brings the untestable-preview problem back and lets a preview run write real
+Airtable and Substack data.
 
 ## Lead path (no submission)
 

--- a/docs/join-form-flow.md
+++ b/docs/join-form-flow.md
@@ -273,10 +273,11 @@ form untestable on deploy previews, whose hostname the Turnstile site key does
 not allow (the widget refuses to render, so no token can exist). The client
 mirrors this, and assumes live until `/api/onboarding-mode` says otherwise.
 
-`ONBOARDING_LIVE=true` therefore has to be scoped to the **Production** context
-in Netlify. Set site-wide it would also make deploy previews live, which both
-brings the untestable-preview problem back and lets a preview run write real
-Airtable and Substack data.
+`ONBOARDING_LIVE=true` therefore has to stay scoped to the **Production**
+context in Netlify, as it is today (production reports `live: true`, deploy
+previews `live: false`). Set site-wide it would also make previews live, which
+both brings the untestable-preview problem back and lets a preview run write
+real Airtable and Substack data.
 
 ## Lead path (no submission)
 

--- a/src/lib/components/onboarding/OnboardingFlow.svelte
+++ b/src/lib/components/onboarding/OnboardingFlow.svelte
@@ -569,9 +569,11 @@
 					{/each}
 				</div>
 				{@render gdprConsentField()}
-				{#key turnstileNonce}
-					<Turnstile bind:token={turnstileToken} />
-				{/key}
+				{#if onboardingLive}
+					{#key turnstileNonce}
+						<Turnstile bind:token={turnstileToken} />
+					{/key}
+				{/if}
 				<button
 					type="submit"
 					class="primary"
@@ -675,9 +677,11 @@
 								/>
 							</div>
 							{@render gdprConsentField()}
-							{#key turnstileNonce}
-								<Turnstile bind:token={turnstileToken} />
-							{/key}
+							{#if onboardingLive}
+								{#key turnstileNonce}
+									<Turnstile bind:token={turnstileToken} />
+								{/key}
+							{/if}
 							<button type="submit" class="primary" disabled={!gdprConsent || !canSubmit}>
 								{submitting ? msgs.onboarding_btn_signing_up : msgs.onboarding_btn_sign_me_up}
 							</button>
@@ -892,9 +896,11 @@
 					<!-- eslint-disable-next-line svelte/no-at-html-tags -->
 					<span>{@html msgs.onboarding_agree_conduct}</span>
 				</label>
-				{#key turnstileNonce}
-					<Turnstile bind:token={turnstileToken} />
-				{/key}
+				{#if onboardingLive}
+					{#key turnstileNonce}
+						<Turnstile bind:token={turnstileToken} />
+					{/key}
+				{/if}
 				<div class="submit-group">
 					<button type="submit" class="primary" disabled={!volunteerFormComplete || !canSubmit}>
 						{submitting ? msgs.onboarding_btn_submitting : msgs.onboarding_btn_submit}

--- a/src/lib/components/onboarding/OnboardingFlow.svelte
+++ b/src/lib/components/onboarding/OnboardingFlow.svelte
@@ -55,6 +55,10 @@
 		initialLanguages?: string[]
 	} = $props()
 
+	// Assume live until the server says otherwise, so an unanswered request keeps the
+	// anti-spam check required rather than dropping it.
+	let onboardingLive = $state(true)
+
 	// Surface stub/live mode in the browser console when the form loads. The
 	// pages embedding the form can be prerendered (e.g. /join), so the runtime
 	// env isn't available at render time, ask the server instead.
@@ -63,6 +67,7 @@
 			const response = await fetch('/api/onboarding-mode')
 			if (!response.ok) return
 			const { live } = (await response.json()) as OnboardingModeApiResponse
+			onboardingLive = live
 			console.log(
 				live
 					? 'Onboarding form: LIVE mode. Submissions write to Airtable.'
@@ -105,7 +110,13 @@
 
 	// Without a configured site key (e.g. local development) there is no widget
 	// to wait for, and the server decides whether to accept the submission.
-	const canSubmit = $derived(!submitting && (!turnstileSiteKey || turnstileToken !== ''))
+	// The token is only required when the submission writes — matching the server,
+	// which skips the check in stub mode. Without this the widget's failure on a
+	// deploy preview (its hostname isn't allowed by the site key) would leave the
+	// button disabled with no way forward.
+	const canSubmit = $derived(
+		!submitting && (!turnstileSiteKey || turnstileToken !== '' || !onboardingLive)
+	)
 
 	// Step 1: basic info (shared with the browse-mode inline signup and the
 	// volunteer form, which pre-fills from the same state)

--- a/src/lib/components/onboarding/OnboardingFlow.svelte
+++ b/src/lib/components/onboarding/OnboardingFlow.svelte
@@ -67,7 +67,9 @@
 			const response = await fetch('/api/onboarding-mode')
 			if (!response.ok) return
 			const { live } = (await response.json()) as OnboardingModeApiResponse
-			onboardingLive = live
+			// Only an explicit false relaxes the check, so a malformed response can't
+			// drop it by being falsy.
+			onboardingLive = live !== false
 			console.log(
 				live
 					? 'Onboarding form: LIVE mode. Submissions write to Airtable.'

--- a/src/lib/components/onboarding/OnboardingFlow.svelte
+++ b/src/lib/components/onboarding/OnboardingFlow.svelte
@@ -55,8 +55,7 @@
 		initialLanguages?: string[]
 	} = $props()
 
-	// Assume live until the server says otherwise, so an unanswered request keeps the
-	// anti-spam check required rather than dropping it.
+	// Starts true so an unanswered request keeps the anti-spam check required.
 	let onboardingLive = $state(true)
 
 	// Surface stub/live mode in the browser console when the form loads. The
@@ -67,8 +66,7 @@
 			const response = await fetch('/api/onboarding-mode')
 			if (!response.ok) return
 			const { live } = (await response.json()) as OnboardingModeApiResponse
-			// Only an explicit false relaxes the check, so a malformed response can't
-			// drop it by being falsy.
+			// Only an explicit false relaxes the check; a malformed response must not.
 			onboardingLive = live !== false
 			console.log(
 				live
@@ -112,10 +110,7 @@
 
 	// Without a configured site key (e.g. local development) there is no widget
 	// to wait for, and the server decides whether to accept the submission.
-	// The token is only required when the submission writes — matching the server,
-	// which skips the check in stub mode. Without this the widget's failure on a
-	// deploy preview (its hostname isn't allowed by the site key) would leave the
-	// button disabled with no way forward.
+	// Nor when the submission doesn't write, matching the server.
 	const canSubmit = $derived(
 		!submitting && (!turnstileSiteKey || turnstileToken !== '' || !onboardingLive)
 	)

--- a/src/lib/components/onboarding/OnboardingFlow.svelte
+++ b/src/lib/components/onboarding/OnboardingFlow.svelte
@@ -57,6 +57,9 @@
 
 	// Starts true so an unanswered request keeps the anti-spam check required.
 	let onboardingLive = $state(true)
+	// The widget waits for the answer: mounting it first makes a preview flash
+	// Turnstile's "could not load" error before it's removed again.
+	let onboardingModeKnown = $state(false)
 
 	// Surface stub/live mode in the browser console when the form loads. The
 	// pages embedding the form can be prerendered (e.g. /join), so the runtime
@@ -75,6 +78,9 @@
 			)
 		} catch {
 			// Mode logging is best-effort; never break the form over it.
+		} finally {
+			// Also on failure: the check stays required, so the widget has to appear.
+			onboardingModeKnown = true
 		}
 	})
 
@@ -564,7 +570,7 @@
 					{/each}
 				</div>
 				{@render gdprConsentField()}
-				{#if onboardingLive}
+				{#if onboardingLive && onboardingModeKnown}
 					{#key turnstileNonce}
 						<Turnstile bind:token={turnstileToken} />
 					{/key}
@@ -672,7 +678,7 @@
 								/>
 							</div>
 							{@render gdprConsentField()}
-							{#if onboardingLive}
+							{#if onboardingLive && onboardingModeKnown}
 								{#key turnstileNonce}
 									<Turnstile bind:token={turnstileToken} />
 								{/key}
@@ -891,7 +897,7 @@
 					<!-- eslint-disable-next-line svelte/no-at-html-tags -->
 					<span>{@html msgs.onboarding_agree_conduct}</span>
 				</label>
-				{#if onboardingLive}
+				{#if onboardingLive && onboardingModeKnown}
 					{#key turnstileNonce}
 						<Turnstile bind:token={turnstileToken} />
 					{/key}

--- a/src/routes/api/onboarding-mode/+server.ts
+++ b/src/routes/api/onboarding-mode/+server.ts
@@ -7,8 +7,9 @@ import type { RequestHandler } from './$types'
 export type OnboardingModeApiResponse = { live: boolean }
 
 // Lets the (prerendered) pages embedding the onboarding form discover at
-// runtime whether submissions are live or stubbed, so the form can log its
-// mode in the browser console on load.
+// runtime whether submissions are live or stubbed. The form logs its mode from
+// this, and decides whether to require an anti-spam token — it assumes live if
+// this doesn't answer, so a failure here costs a widget, not protection.
 export const GET: RequestHandler = () => {
 	const body: OnboardingModeApiResponse = { live: isOnboardingLive() }
 	return json(body, { headers: { 'cache-control': 'no-store' } })

--- a/src/routes/embed/onboarding-form/+page.server.ts
+++ b/src/routes/embed/onboarding-form/+page.server.ts
@@ -74,12 +74,16 @@ export const actions: Actions = {
 			return { success: true }
 		}
 
+		// Read once and use for both the check below and the writes at the end, so the
+		// two cannot disagree even in principle.
+		const live = isOnboardingLive()
+
 		// Turnstile bot protection. Only when submissions actually write: in stub mode
 		// there is no record, no subscription and no mail to protect, and requiring it
 		// there makes the form untestable on deploy previews, whose hostname the
 		// Turnstile site key does not allow (the widget refuses to render, so no token
 		// can exist). Live deploys are unaffected — they always verify.
-		if (isOnboardingLive()) {
+		if (live) {
 			const spam = await checkNotSpam(data, url.hostname)
 			if (spam.drop) return { success: true }
 			if (spam.message) return fail(403, { message: spam.message })
@@ -185,7 +189,7 @@ export const actions: Actions = {
 		// Airtable process (plan decision 6).
 		const chapter = await lookupChapter(fetch, country)
 
-		if (isOnboardingLive()) {
+		if (live) {
 			let recordId: string | undefined = existingRecordId || undefined
 			if (recordId) {
 				const updated = await updateRecord(AIRTABLE_BASE_ID, MEMBERS_TABLE_ID, recordId, fields)

--- a/src/routes/embed/onboarding-form/+page.server.ts
+++ b/src/routes/embed/onboarding-form/+page.server.ts
@@ -74,15 +74,11 @@ export const actions: Actions = {
 			return { success: true }
 		}
 
-		// Read once and use for both the check below and the writes at the end, so the
-		// two cannot disagree even in principle.
+		// Read once, so the check below and the writes at the end can't disagree.
 		const live = isOnboardingLive()
 
-		// Turnstile bot protection. Only when submissions actually write: in stub mode
-		// there is no record, no subscription and no mail to protect, and requiring it
-		// there makes the form untestable on deploy previews, whose hostname the
-		// Turnstile site key does not allow (the widget refuses to render, so no token
-		// can exist). Live deploys are unaffected — they always verify.
+		// Only when the submission writes: a preview can't produce a token at all
+		// (its hostname isn't allowed by the site key), and stub mode writes nothing.
 		if (live) {
 			const spam = await checkNotSpam(data, url.hostname)
 			if (spam.drop) return { success: true }

--- a/src/routes/embed/onboarding-form/+page.server.ts
+++ b/src/routes/embed/onboarding-form/+page.server.ts
@@ -74,10 +74,16 @@ export const actions: Actions = {
 			return { success: true }
 		}
 
-		// Turnstile bot protection
-		const spam = await checkNotSpam(data, url.hostname)
-		if (spam.drop) return { success: true }
-		if (spam.message) return fail(403, { message: spam.message })
+		// Turnstile bot protection. Only when submissions actually write: in stub mode
+		// there is no record, no subscription and no mail to protect, and requiring it
+		// there makes the form untestable on deploy previews, whose hostname the
+		// Turnstile site key does not allow (the widget refuses to render, so no token
+		// can exist). Live deploys are unaffected — they always verify.
+		if (isOnboardingLive()) {
+			const spam = await checkNotSpam(data, url.hostname)
+			if (spam.drop) return { success: true }
+			if (spam.message) return fail(403, { message: spam.message })
+		}
 
 		const fullName = getString(data, 'full_name')
 		const email = getString(data, 'email')


### PR DESCRIPTION
## The problem

The signup form can't be tested on deploy previews. The Turnstile site key only allows the production hostname, so on a preview the widget refuses to render (Cloudflare error `110200`), no token can exist, and the submit button waits for one forever. This affects `/join` on every preview today.

## The fix

The check now runs only when a submission actually **writes**. Live deploys verify exactly as before; in stub mode there is no record, no subscription and no mail to protect.

The client follows the same rule — assuming live until told otherwise, so an unanswered mode request keeps the check required — and the widget is only rendered when a token is needed, instead of showing a "could not load" error next to a working button.

## Deliberately not done

Pointing previews at Cloudflare's test keys. `turnstile-verify.ts` refuses those outside dev on purpose, since a test secret accepts every token.

Extending this to `/contact-us`. That form can send mail on any deploy, so unlike the stubbed signup form it has something to protect, and it keeps its check everywhere. (It isn't testable on previews either way — no mail key is configured there, so it stops at "email service is not configured".)

## Config note

`ONBOARDING_LIVE=true` needs to stay scoped to the Production context, as it already is — set site-wide it would make previews live, bringing this back and letting a preview run write real data.
