### PR TITLE
style: format 2024-february.md, unbreaking CI on main

### DIFF
--- a/src/posts/2024-february.md
+++ b/src/posts/2024-february.md
@@ -39,7 +39,6 @@ According to their charter, “OpenAI’s mission is to ensure that artificial g
 - [ReadWrite](https://readwrite.com/stop-working-with-pentagon-openai-staff-face-protests/)
 - [VentureBeat](https://venturebeat.com/ai/protesters-gather-outside-openai-office-opposing-military-ai-and-agi/)
 
-
 <WidgetConsent>
 <div>
 <blockquote class="twitter-tweet"><p lang="en" dir="ltr">From the protest yesterday at OpenAI HQ, covered in Bloomberg: <a href="https://t.co/sgp1KFoFPs">https://t.co/sgp1KFoFPs</a> <a href="https://t.co/N6fHGIlOYm">pic.twitter.com/N6fHGIlOYm</a></p>&mdash; PauseAI US ⏸️ (@pauseaius) <a href="https://twitter.com/pauseaius/status/1757604719047114786?ref_src=twsrc%5Etfw">February 14, 2024</a></blockquote> <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>


### PR DESCRIPTION
`src/posts/2024-february.md` picked up a double blank line in ae9345ff, which prettier rejects, so `pnpm check` is failing on `main` and every open PR inherits it through the merge ref.

The fix is `prettier --write` on that one file: a single blank line removed, no content change.

Worth knowing for next time: edits made through GitHub's own web editor bypass the local pre-commit formatter, so they can land unformatted even though the same edit made locally could not. (The CMS does run Prettier, per @Wituareard below, so this is specific to the GitHub UI.)

