### PR TITLE
feat(onboarding): stop writing 'Keep informed' as an Intent

### DIFF
--- a/docs/join-form-flow.md
+++ b/docs/join-form-flow.md
@@ -80,8 +80,8 @@ basics (name, email, country, city) plus two opt-ins. Four of its hidden inputs
 carry meaning: `subscribe_form=1` is the discriminator, `agree_gdpr=on` records
 that signing up here is itself the consent, `keep_informed=on` is posted
 unconditionally so every completed submission subscribes, and
-`intent=Keep informed` is fixed, so every row this route creates starts at that
-intent whatever the person later chooses.
+`intent=None` is fixed, because the form never asks about intent: the row records
+no intent until the person picks one in the "Get involved" continuation.
 
 `SubscribeFlow` is a three-phase machine rather than a step counter:
 
@@ -354,7 +354,8 @@ an update is in "Create versus update" above.
 - `country` must be in `COUNTRIES`, checked only when one is supplied.
 - `intent` must be one of `INTENTS` (`None` | `Keep informed` | `Act now` |
   `Volunteer` | `Lead`). Step 2 submits `None` when no intent is picked; the
-  browse signup hardcodes `Act now`; `/subscribe` hardcodes `Keep informed`.
+  browse signup hardcodes `Act now`; `/subscribe` hardcodes `None`. Nothing writes
+  `Keep informed` any more; it remains a valid value only for rows already carrying it.
 - GDPR consent (`agree_gdpr`) required **only on the create path** — step-3
   volunteer updates are exempt because consent was captured at step 2.
   `/subscribe` posts it as a hidden field, since signing up on that form is

--- a/docs/join-form-flow.md
+++ b/docs/join-form-flow.md
@@ -354,8 +354,9 @@ an update is in "Create versus update" above.
 - `country` must be in `COUNTRIES`, checked only when one is supplied.
 - `intent` must be one of `INTENTS` (`None` | `Keep informed` | `Act now` |
   `Volunteer` | `Lead`). Step 2 submits `None` when no intent is picked; the
-  browse signup hardcodes `Act now`; `/subscribe` hardcodes `None`. Nothing writes
-  `Keep informed` any more; it remains a valid value only for rows already carrying it.
+  browse signup hardcodes `Act now`; `/subscribe` hardcodes `None`. No form emits
+  `Keep informed` any more, but it stays in `INTENTS` so a post carrying it is still
+  accepted rather than rejected.
 - GDPR consent (`agree_gdpr`) required **only on the create path** — step-3
   volunteer updates are exempt because consent was captured at step 2.
   `/subscribe` posts it as a hidden field, since signing up on that form is

--- a/src/lib/components/onboarding/OnboardingFlow.svelte
+++ b/src/lib/components/onboarding/OnboardingFlow.svelte
@@ -554,11 +554,7 @@
 				{#if recordId}
 					<input type="hidden" name="record_id" value={recordId} />
 				{/if}
-				<input
-					type="hidden"
-					name="intent"
-					value={intent ? INTENT_VALUES[intent] : isContinuation ? 'Keep informed' : 'None'}
-				/>
+				<input type="hidden" name="intent" value={intent ? INTENT_VALUES[intent] : 'None'} />
 				<!-- The server writes Email subscription from this post every time, so a
 				     post without this input clears the flag. Both forms that can update
 				     the record have to carry it. -->

--- a/src/lib/components/onboarding/SubscribeFlow.svelte
+++ b/src/lib/components/onboarding/SubscribeFlow.svelte
@@ -144,7 +144,7 @@
 			     only when the local-chapter box is ticked. -->
 			<input type="hidden" name="subscribe_form" value="1" />
 			<input type="hidden" name="mode" value="contact" />
-			<input type="hidden" name="intent" value="Keep informed" />
+			<input type="hidden" name="intent" value="None" />
 			<input type="hidden" name="keep_informed" value="on" />
 			<input type="hidden" name="agree_gdpr" value="on" />
 

--- a/src/lib/components/onboarding/options.ts
+++ b/src/lib/components/onboarding/options.ts
@@ -1,9 +1,11 @@
 // Controlled vocabularies for the onboarding pipeline form.
 import type { OnboardingMessages } from './messages'
 
-// 'None' is what /join step 2 submits when nothing is picked; /subscribe keeps
-// writing 'Keep informed'. Each value must exist as an Airtable Intent select
-// option and in the CRM's member_intent vocabulary.
+// 'None' is what both forms submit when the person picked no intent: /join step 2
+// offers Act now / Volunteer / Lead, and /subscribe never asks. 'Keep informed' is
+// no longer written by anything, and stays only so historical rows typecheck.
+// Each value must exist as an Airtable Intent select option and in the CRM's
+// member_intent vocabulary.
 export const INTENTS = ['None', 'Keep informed', 'Act now', 'Volunteer', 'Lead'] as const
 export type Intent = (typeof INTENTS)[number]
 export type IntentKey = 'act-now' | 'volunteer' | 'lead'

--- a/src/lib/components/onboarding/options.ts
+++ b/src/lib/components/onboarding/options.ts
@@ -2,10 +2,11 @@
 import type { OnboardingMessages } from './messages'
 
 // 'None' is what both forms submit when the person picked no intent: /join step 2
-// offers Act now / Volunteer / Lead, and /subscribe never asks. 'Keep informed' is
-// no longer written by anything, and stays only so historical rows typecheck.
-// Each value must exist as an Airtable Intent select option and in the CRM's
-// member_intent vocabulary.
+// offers Act now / Volunteer / Lead, and /subscribe never asks. No form emits
+// 'Keep informed' any more; it stays listed because the server validates posted
+// intents against INTENTS (isIntent), so dropping it would start rejecting a post
+// that is still legitimate. Each value must exist as an Airtable Intent select
+// option and in the CRM's member_intent vocabulary.
 export const INTENTS = ['None', 'Keep informed', 'Act now', 'Volunteer', 'Lead'] as const
 export type Intent = (typeof INTENTS)[number]
 export type IntentKey = 'act-now' | 'volunteer' | 'lead'


### PR DESCRIPTION
Closes #1057. Stacked on #1014 (`prototype/onboarding-v2-two-axis`), because `None` only exists as a value once that lands.

`/subscribe` hardcoded `intent=Keep informed`, a value no form offers as a choice. `/join`'s options are Act now / Volunteer / Lead, and after #1014 picking none writes `None`. So the field carried a value nobody could pick, which reads as a choice the person made.

## The change

Both forms now submit `None` when the person picked no intent. `Intent` then means exactly one thing: **which of the offered options they picked, or none.** Provenance stays in `Signup source` (`June 2026 subscribe form`), which the CRM already treats as authoritative for these rows.

Three lines plus the docs:

- `SubscribeFlow.svelte`: the hidden input writes `None`.
- `OnboardingFlow.svelte`: collapses the `isContinuation` arm of the `/join` fallback (see below).
- `options.ts` + `docs/join-form-flow.md`: prose that described the old split.

## Why the continuation arm goes too

#1014 writes `intent ? INTENT_VALUES[intent] : isContinuation ? 'Keep informed' : 'None'`. That `isContinuation` arm is **unreachable**: the step-2 submit button carries `disabled={(isContinuation ? !intent : ...)}`, so a continuation cannot be submitted while `intent` is falsy, and the fallback only evaluates when it is falsy.

Dropping it is therefore behaviourally inert today. It is worth doing because it would otherwise be the last remaining `Keep informed` writer in the codebase, guarded only by a client-side `disabled` attribute. If that guard is ever relaxed, `Keep informed` writes resume silently and nothing reports it, since the value stays deliberately valid in the CRM vocabulary for historical rows.

## Behaviourally inert

Every consumer treats `None` and `Keep informed` identically, so this changes analytics semantics only:

- `chapter_optin()` — neither value is in `CHAPTER_OPTIN_INTENTS`; the subscribe branch keys on chapter-share consent anyway.
- The Airtable escalation automation (`wfl6875hJNujN1gx0`) — triggers on Intent entering Volunteer/Lead.
- The welcome/verification email — anything not Volunteer/Lead routes to the non-volunteer template.
- The onboarder alert filters — subscribe rows post `keep_informed=on`, which is what those read.

## What it costs

`Intent` alone stops distinguishing "picked nothing on /join" from "came via /subscribe"; that query goes through `Signup source` instead. Accepted: that field exists for provenance and is authoritative for this cohort.

## Legacy

No form emits `Keep informed` any more. It stays in `INTENTS` because that list is the server's accepted-POST allowlist (`isIntent` in `embed/onboarding-form/+page.server.ts`), so dropping it would start rejecting a post rather than merely retiring a label. Migration cost is near nil: 106 rows carry it today, of which exactly **one** is a `June 2026 subscribe form` row (created 2026-08-20); the other 105 are pre-#1014 `/join` defaults.

## CRM side

PauseAI/pauseai-civicrm#530 adds `None` to the `member_intent` vocabulary and is already open. Nothing further is needed there: the import and the System Status vocabulary guard both read the active option values dynamically.

## Verification

`pnpm check` and `pnpm lint` both green locally (remaining warnings are pre-existing and untouched).
