### PR TITLE
chore: sync national chapters from live API

### DIFF
--- a/.github/workflows/sync-national-chapters.yml
+++ b/.github/workflows/sync-national-chapters.yml
@@ -1,0 +1,50 @@
+name: Sync national chapters
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Daily so chapter changes in Airtable show up as a reviewable PR
+    - cron: '0 6 * * *'
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  sync:
+    name: Sync national-chapters.json with pauseai.info
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run sync
+        run: pnpm sync:national-chapters
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v8
+        with:
+          commit-message: 'Sync national chapters with pauseai.info'
+          title: 'Sync national chapters with pauseai.info'
+          body: |
+            This PR was automatically created by the **Sync national chapters** workflow.
+
+            The committed `national-chapters.json` was out of sync with the
+            national groups served by pauseai.info. It has been regenerated
+            with `pnpm sync:national-chapters` — review the link/coordinate
+            changes before merging.
+          branch: sync-national-chapters
+          base: main
+          delete-branch: true

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
 		"_lint:prettier": "tsx scripts/generate-prettier-ignore.ts && prettier --check .",
 		"format": "tsx scripts/generate-prettier-ignore.ts && prettier --write --ignore-unknown",
 		"prepare": "lefthook install",
-		"sync": "svelte-kit sync"
+		"sync": "svelte-kit sync",
+		"sync:national-chapters": "tsx scripts/sync-national-chapters.ts"
 	},
 	"devDependencies": {
 		"@eslint/js": "^10.0.1",

--- a/scripts/sync-national-chapters.ts
+++ b/scripts/sync-national-chapters.ts
@@ -57,13 +57,8 @@ const NOMINATIM_USER_AGENT =
 	'PauseAI-website-national-chapters-sync (github.com/PauseAI/pauseai-website)'
 const NOMINATIM_MIN_INTERVAL_MS = 1000
 
-type Chapter = {
-	name: string
-	lat: number
-	lon: number
-	link: string
-	country_local?: string
-}
+// Inferred from the JSON so the type can't drift from the data it describes.
+type Chapter = (typeof nationalChaptersJson.communities)[number]
 
 const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms))
 

--- a/scripts/sync-national-chapters.ts
+++ b/scripts/sync-national-chapters.ts
@@ -1,0 +1,212 @@
+/**
+ * Syncs src/routes/communities/national-chapters.json with the national groups
+ * served by https://pauseai.info/api/national-groups (backed by the Airtable
+ * "National groups" table).
+ *
+ * Behavior:
+ * - Chapters already present in the JSON are preserved verbatim: their
+ *   coordinates and country_local labels were hand-picked and the API has
+ *   neither, so they are never regenerated.
+ * - Chapters whose link changed are updated. Changes are non-invasive: only
+ *   outdated values are touched, never the ordering of existing entries.
+ * - Countries that are new to the JSON are appended, geocoded (Nominatim,
+ *   one request per second, honoring their fair-use policy) to get map
+ *   coordinates.
+ * - Entries that are not countries (e.g. the "Legal" entity) fail geocoding
+ *   and are skipped with a warning.
+ * - Countries removed from the JSON (e.g. "United States", see PR #1056) are
+ *   not re-added; pass --allow "United States" to opt back in explicitly.
+ *
+ * Usage:
+ *   pnpm sync:national-chapters
+ *   pnpm sync:national-chapters -- --check      (exit 1 if the file would change; for CI)
+ *   pnpm sync:national-chapters -- --dry-run    (print the would-be output, write nothing)
+ *   pnpm sync:national-chapters -- --allow "United States"   (re-add an excluded country)
+ */
+import fs from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import minimist from 'minimist'
+import type { NationalGroup } from '../src/lib/types.js'
+import nationalChaptersJson from '../src/routes/communities/national-chapters.json'
+
+const TARGET_FILE = fileURLToPath(
+	new URL('../src/routes/communities/national-chapters.json', import.meta.url)
+)
+
+/**
+ * Airtable country name → chapter name to keep in national-chapters.json.
+ * Local groups in pauseai-communities.json match their national chapter via
+ * `parent_name.includes(chapter.name)`, so a rename here would silently
+ * orphan them; pin those names instead.
+ */
+const NAME_OVERRIDES: Record<string, string> = {
+	'Czech Republic': 'Czechia'
+}
+
+/**
+ * Countries deliberately excluded from the map. "United States" was removed in
+ * PR #1056 (the chapter paused its activities); pass --allow "United States"
+ * to the sync script re-add it.
+ */
+const EXCLUDED_COUNTRIES = ['United States']
+
+const NOMINATIM_URL = 'https://nominatim.openstreetmap.org/search'
+// Nominatim's usage policy requires a descriptive User-Agent and at most one
+// request per second.
+const NOMINATIM_USER_AGENT =
+	'PauseAI-website-national-chapters-sync (github.com/PauseAI/pauseai-website)'
+const NOMINATIM_MIN_INTERVAL_MS = 1000
+
+type Chapter = {
+	name: string
+	lat: number
+	lon: number
+	link: string
+	country_local?: string
+}
+
+const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms))
+
+/** Resolves a country name to [lat, lon] using Nominatim, or null if unknown. */
+async function geocodeCountry(country: string): Promise<[number, number] | null> {
+	const url = `${NOMINATIM_URL}?country=${encodeURIComponent(country)}&format=json&limit=1`
+	await sleep(NOMINATIM_MIN_INTERVAL_MS)
+	const response = await fetch(url, {
+		// Nominatim's usage policy requires a descriptive User-Agent identifying
+		// the app; add From as recommended for API consumers.
+		headers: { 'User-Agent': NOMINATIM_USER_AGENT, From: 'tech@pauseai.info' }
+	})
+	if (!response.ok) {
+		console.warn(`  ⚠ Geocoding ${country} failed: HTTP ${response.status}`)
+		return null
+	}
+	const results = (await response.json()) as { lat: string; lon: string; addresstype?: string }[]
+	const match = results.find((r) => r.addresstype === 'country') ?? results[0]
+	if (!match) return null
+	return [Number(match.lat), Number(match.lon)]
+}
+
+/**
+ * Chooses the primary link for a national group, mirroring the preference the
+ * national-groups page uses (website first, then chat platforms, then email).
+ */
+function primaryLink(group: NationalGroup): string {
+	const candidates = [
+		group.website,
+		group.whatsappLink,
+		group.discordLink,
+		group.lumaLink,
+		group.linktreeLink,
+		group.instagramLink,
+		group.tiktokLink,
+		group.facebookLink,
+		group.youtubeLink,
+		group.linkedinLink,
+		group.substackLink,
+		group.xLink
+	]
+	for (const link of candidates) {
+		const trimmed = link?.trim()
+		if (trimmed) return trimmed
+	}
+	return group.email ? `mailto:${group.email}` : ``
+}
+
+async function fetchNationalGroups(): Promise<NationalGroup[]> {
+	const response = await fetch('https://pauseai.info/api/national-groups')
+	if (!response.ok) {
+		throw new Error(
+			`pauseai.info/api/national-groups request failed: ${response.status} ${response.statusText}`
+		)
+	}
+	return (await response.json()) as NationalGroup[]
+}
+
+const argv = minimist<{ allow: string | string[]; check?: boolean; 'dry-run'?: boolean }>(
+	process.argv.slice(2),
+	{
+		string: ['allow'],
+		boolean: ['check', 'dry-run'],
+		default: { allow: [] }
+	}
+)
+const allow = new Set<string>(
+	(Array.isArray(argv.allow) ? argv.allow : [argv.allow]).map((c) => c.toLowerCase())
+)
+
+const current = fs.readFileSync(TARGET_FILE, 'utf8')
+const { communities: existing } = nationalChaptersJson
+const groups = await fetchNationalGroups()
+const groupName = (group: NationalGroup): string =>
+	NAME_OVERRIDES[group.name.trim()] ?? group.name.trim()
+
+const chapters: Chapter[] = []
+const skipped: string[] = []
+
+// Existing chapters keep their position in the file; only update their link
+// when it changed, or drop them when the API no longer lists them.
+for (const chapter of existing) {
+	const group = groups.find((g) => groupName(g) === chapter.name)
+	if (!group) {
+		console.log(`  – Removing ${chapter.name}: no longer listed as an active national group`)
+		continue
+	}
+	const link = primaryLink(group)
+	if (link !== chapter.link) {
+		console.log(`  – Updating link for ${chapter.name}: ${chapter.link} → ${link}`)
+		chapters.push({ ...chapter, link })
+	} else {
+		chapters.push(chapter)
+	}
+}
+
+// New countries are appended at the end, geocoded to get map coordinates.
+for (const group of groups) {
+	const name = groupName(group)
+	if (existing.some((c) => c.name === name)) continue
+
+	if (EXCLUDED_COUNTRIES.some((c) => c.toLowerCase() === name.toLowerCase())) {
+		if (allow.has(name.toLowerCase())) {
+			// fall through to the new-country path below
+		} else {
+			console.log(`  – Skipping excluded country: ${name} (pass --allow "${name}" to add it)`)
+			continue
+		}
+	}
+
+	const link = primaryLink(group)
+	const coords = await geocodeCountry(group.name.trim())
+	if (!coords) {
+		skipped.push(name)
+		console.warn(`  ⚠ Could not geocode "${name}" — is it a real country? Skipping.`)
+		continue
+	}
+
+	console.log(`  + Adding new country: ${name}`)
+	chapters.push({ name, lat: coords[0], lon: coords[1], link })
+}
+
+if (skipped.length > 0) {
+	console.warn(`  ⚠ Skipped ${skipped.length} non-country entries: ${skipped.join(', ')}`)
+}
+console.log(`  ${existing.length} existing chapters, ${chapters.length} chapters in output`)
+
+const next = JSON.stringify({ communities: chapters }, null, '\t') + '\n'
+
+// The repo has no .gitattributes for JSON, so on Windows checkouts git may
+// materialize the file with CRLF. Normalize before comparing (writing still
+// uses the LF output, which git normalizes on commit).
+const normalize = (text: string): string => text.replace(/\r\n/g, '\n')
+if (normalize(next) === normalize(current)) {
+	console.log('✓ national-chapters.json is in sync with pauseai.info')
+} else if (argv['dry-run']) {
+	console.log(next)
+} else if (argv.check) {
+	console.error(
+		'✗ national-chapters.json is out of sync with pauseai.info. Run `pnpm sync:national-chapters` locally and commit the result.'
+	)
+	process.exit(1)
+} else {
+	fs.writeFileSync(TARGET_FILE, next)
+	console.log('✓ Updated national-chapters.json')
+}

--- a/scripts/sync-national-chapters.ts
+++ b/scripts/sync-national-chapters.ts
@@ -13,7 +13,10 @@
  *   one request per second, honoring their fair-use policy) to get map
  *   coordinates.
  * - Entries that are not countries (e.g. the "Legal" entity) fail geocoding
- *   and are skipped with a warning.
+ *   and are skipped with a warning. Countries whose English name already is
+ *   the local name (Kenya, Australia, ...) and countries with multiple
+ *   official languages (Belgium, Switzerland, ...) are added without
+ *   country_local.
  * - Countries removed from the JSON (e.g. "United States", see PR #1056) are
  *   not re-added; pass --allow "United States" to opt back in explicitly.
  *
@@ -62,23 +65,44 @@ type Chapter = (typeof nationalChaptersJson.communities)[number]
 
 const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms))
 
-/** Resolves a country name to [lat, lon] using Nominatim, or null if unknown. */
-async function geocodeCountry(country: string): Promise<[number, number] | null> {
+/**
+ * Resolves a country name to coordinates and local name using Nominatim,
+ * or null if unknown.
+ */
+async function geocodeCountry(
+	country: string
+): Promise<{ coords: [number, number]; localName?: string } | null> {
 	const url = `${NOMINATIM_URL}?country=${encodeURIComponent(country)}&format=json&limit=1`
 	await sleep(NOMINATIM_MIN_INTERVAL_MS)
 	const response = await fetch(url, {
 		// Nominatim's usage policy requires a descriptive User-Agent identifying
-		// the app; add From as recommended for API consumers.
+		// the app; add From as recommended for API consumers. No accept-language:
+		// without one, Nominatim serves the plain OSM `name` tag, which follows
+		// the local convention (Deutschland, Česko, ...).
 		headers: { 'User-Agent': NOMINATIM_USER_AGENT, From: 'tech@pauseai.info' }
 	})
 	if (!response.ok) {
 		console.warn(`  ⚠ Geocoding ${country} failed: HTTP ${response.status}`)
 		return null
 	}
-	const results = (await response.json()) as { lat: string; lon: string; addresstype?: string }[]
+	const results = (await response.json()) as {
+		lat: string
+		lon: string
+		name?: string
+		addresstype?: string
+	}[]
 	const match = results.find((r) => r.addresstype === 'country') ?? results[0]
 	if (!match) return null
-	return [Number(match.lat), Number(match.lon)]
+	// Multi-language countries carry all names joined with "/" in the default
+	// name tag; without an authoritative pick, omit country_local rather than
+	// guessing one. English-identical names (Kenya, Australia, ...) carry no
+	// information and are omitted too.
+	const name = match.name?.trim() || undefined
+	const localName =
+		!name || name.includes('/') || name.toLowerCase() === country.trim().toLowerCase()
+			? undefined
+			: name
+	return { coords: [Number(match.lat), Number(match.lon)], localName }
 }
 
 /**
@@ -170,15 +194,21 @@ for (const group of groups) {
 	}
 
 	const link = primaryLink(group)
-	const coords = await geocodeCountry(group.name.trim())
-	if (!coords) {
+	const geocoded = await geocodeCountry(group.name.trim())
+	if (!geocoded) {
 		skipped.push(name)
 		console.warn(`  ⚠ Could not geocode "${name}" — is it a real country? Skipping.`)
 		continue
 	}
 
-	console.log(`  + Adding new country: ${name}`)
-	chapters.push({ name, lat: coords[0], lon: coords[1], link })
+	const local = geocoded.localName ? { country_local: geocoded.localName } : {}
+	if (!geocoded.localName) {
+		console.log(`  – "${name}" has no distinct local name; adding without country_local`)
+	}
+	console.log(
+		`  + Adding new country: ${name}${geocoded.localName ? ` (${geocoded.localName})` : ''}`
+	)
+	chapters.push({ name, lat: geocoded.coords[0], lon: geocoded.coords[1], link, ...local })
 }
 
 if (skipped.length > 0) {

--- a/src/routes/communities/national-chapters.json
+++ b/src/routes/communities/national-chapters.json
@@ -120,7 +120,7 @@
 			"name": "Switzerland",
 			"lat": 46.7985624,
 			"lon": 8.2319736,
-			"link": "mailto:guillaume@pauseai.info"
+			"link": "https://chat.whatsapp.com/BKt0uKPVLDKFLomW4CrTVH"
 		}
 	]
 }

--- a/src/routes/communities/national-chapters.json
+++ b/src/routes/communities/national-chapters.json
@@ -37,7 +37,7 @@
 			"country_local": "România",
 			"lat": 44.5,
 			"lon": 26,
-			"link": "https://www.facebook.com/people/Pause-AI-Romania/61581783381263/?rdid=LfnCxIeWHG9TL4Bp&share_url=https%3A%2F%2Fwww.facebook.com%2Fshare%2F19yinn6qj4%2F"
+			"link": "https://pauseai.ro/"
 		},
 		{
 			"name": "Kenya",
@@ -63,7 +63,7 @@
 			"country_local": "Deutschland",
 			"lat": 51.1,
 			"lon": 10,
-			"link": "https://pause-ai.de/"
+			"link": "https://www.pause-ai.de/"
 		},
 		{
 			"name": "Czechia",
@@ -76,7 +76,7 @@
 			"country_local": "Polska",
 			"lat": 52,
 			"lon": 19.5,
-			"link": "mailto:patryk@pauseai.info"
+			"link": "https://pauseai.pl/"
 		},
 		{
 			"name": "Nigeria",
@@ -96,7 +96,31 @@
 			"country_local": "Italia",
 			"lat": 42.5,
 			"lon": 12.5,
-			"link": "$$WHATSAPP_ITALY$$"
+			"link": "https://www.pauseai.it/"
+		},
+		{
+			"name": "Belgium",
+			"lat": 50.6402809,
+			"lon": 4.6667145,
+			"link": "mailto:Didier@pauseai.info"
+		},
+		{
+			"name": "Ghana",
+			"lat": 8.0300284,
+			"lon": -1.0800271,
+			"link": "mailto:ewura@pauseai.info"
+		},
+		{
+			"name": "Ireland",
+			"lat": 52.865196,
+			"lon": -7.9794599,
+			"link": "mailto:katiemartin@pauseai.info"
+		},
+		{
+			"name": "Switzerland",
+			"lat": 46.7985624,
+			"lon": 8.2319736,
+			"link": "mailto:guillaume@pauseai.info"
 		}
 	]
 }

--- a/src/routes/communities/national-chapters.json
+++ b/src/routes/communities/national-chapters.json
@@ -67,6 +67,7 @@
 		},
 		{
 			"name": "Czechia",
+			"country_local": "Česko",
 			"lat": 50,
 			"lon": 15,
 			"link": "https://www.pauseai.cz/"


### PR DESCRIPTION
## Summary

Adds `pnpm sync:national-chapters`, a script that reconciles [national-chapters.json](src/routes/communities/national-chapters.json) against the live API at `https://pauseai.info/api/national-groups` (the same data source the `/communities` page endpoint proxies), plus a scheduled GitHub Actions workflow that opens a PR when they drift.

## What changed

- **[scripts/sync-national-chapters.ts](scripts/sync-national-chapters.ts)** — single-file script:
  - Fetches groups from the live API (no Airtable dependency; no credentials needed).
  - Merges **non-invasively**: existing entries keep their file order and are only touched when a link is outdated; new countries are appended at the end; delisted countries are removed.
  - Geocodes **only new countries** (Nominatim, 1 req/s, descriptive User-Agent/From headers).
  - `NAME_OVERRIDES` pins `Czech Republic` → `Czechia` so local Czech groups in `pauseai-communities.json` stay grouped under the chapter (they match via `parent_name.includes(chapter.name)`).
  - `EXCLUDED_COUNTRIES`: `United States` stays out (removed in #1056); `--allow "United States"` re-adds.
  - Flags: `--check` (exit 1 on drift, no writes), `--dry-run` (print without writing).
- **[.github/workflows/sync-national-chapters.yml](.github/workflows/sync-national-chapters.yml)** — daily 06:00 UTC + manual dispatch. Runs the sync in **write** mode so `peter-evans/create-pull-request@v8` can commit any diff to the `sync-national-chapters` branch as a reviewable PR (no-op when in sync). No secrets required.
- **[package.json](package.json)** — `sync:national-chapters` script.
- **[national-chapters.json](src/routes/communities/national-chapters.json)** — refreshed output: 15 → 19 chapters. Original 15 entries keep their order; 4 stale links updated in place (Germany, Italy — placeholder `$$WHATSAPP_ITALY$$` resolved, Poland, Romania); Belgium, Ghana, Ireland, Switzerland appended (these live groups have no platform links yet, so `mailto:` is faithful to the API — future Airtable link updates flow through automatically on the next run).

## Validation

- Script: `--check` exits 0 in sync / 1 on drift (verified with a mutated link); `--dry-run` non-destructive; plain run regenerates correctly.
- `pnpm check`: 0 errors (only pre-existing svelte warnings).
- `pnpm lint`: passes (only pre-existing LanguageSwitcher warnings).
- `pnpm test`: 51/51 pass.

## Notes for reviewers

- Run locally with `pnpm sync:national-chapters -- --dry-run` to preview.
- Merges are not auto-created: every change lands as a PR for review.