### PR TITLE
feat(onboarding): require a UK postcode on step 1

### DIFF
--- a/docs/join-form-flow.md
+++ b/docs/join-form-flow.md
@@ -210,7 +210,7 @@ allowlists, and the live/stub switch only need to be maintained in one place.
 ```mermaid
 stateDiagram-v2
     [*] --> Step1
-    Step1: Step 1 — Basic info<br/>(name, email, country, city)
+    Step1: Step 1 — Basic info<br/>(name, email, country, city,<br/>UK postcode when country = United Kingdom)
     Step1 --> Step2: Continue (client-side, mode=contact)
     Step1 --> Browse: "I just want to take action now" (mode=browse)
     Browse: Browse mode<br/>(act-now, no signup)<br/>includes ActionCards
@@ -320,7 +320,9 @@ Target: base `appWPTGqZmUcs3NWu`, table `tblL1icZBhTV1gQ9o` ("Members").
 **Step 2 / browse signup / subscribe form (create):** `Full name`, `Email`,
 `Country`, `City`, `Intent`, `Signup source`, `Source page` (when resolved),
 `Email subscription` (keep_informed), `Data privacy policy agreed`,
-`GDPR chapter share permission`.
+`GDPR chapter share permission`, plus `Zip code` when `country` is
+`United Kingdom` (the step-1 UK postcode — see "Validation rules" — carried in
+the `zip_code` field, sharing it with the US volunteer ZIP below).
 Every field there has a rule under "Create versus update" above or "Chapter
 sharing" below, so treat this list as the index to those rules.
 
@@ -370,6 +372,13 @@ an update is in "Create versus update" above.
 - Required: `full_name`, `email`, `country`, `city`.
 - `email` must match `^\S+@\S+\.\S+$`.
 - `country` must be in `COUNTRIES`, checked only when one is supplied.
+- UK postcode (`zip_code`) is required on a **create** when `country` is
+  `United Kingdom`, and must match `UK_POSTCODE_PATTERN` — the outward code alone
+  (`SW1A`) or a full postcode (`SW1A 1AA`). Collected on step 1 and the browse
+  signup, stored normalised (uppercased, single-spaced) in Airtable's `Zip code`
+  field. Not re-checked on an update; the volunteer step reposts it from state.
+  For a non-UK country the field is ignored. The US volunteer ZIP uses the same
+  `zip_code` field on the step-3 form (see below).
 - `intent` must be one of `INTENTS` (`None` | `Keep informed` | `Act now` |
   `Volunteer` | `Lead`). Step 2 submits `None` when no intent is picked; the
   browse signup hardcodes `Act now`; `/subscribe` hardcodes `None`. No form emits

--- a/docs/join-form-flow.md
+++ b/docs/join-form-flow.md
@@ -373,12 +373,14 @@ an update is in "Create versus update" above.
 - `email` must match `^\S+@\S+\.\S+$`.
 - `country` must be in `COUNTRIES`, checked only when one is supplied.
 - UK postcode (`zip_code`) is required on a **create** when `country` is
-  `United Kingdom`, and must match `UK_POSTCODE_PATTERN` — the outward code alone
-  (`SW1A`) or a full postcode (`SW1A 1AA`). Collected on step 1 and the browse
-  signup, stored normalised (uppercased, single-spaced) in Airtable's `Zip code`
-  field. Not re-checked on an update; the volunteer step reposts it from state.
-  For a non-UK country the field is ignored. The US volunteer ZIP uses the same
-  `zip_code` field on the step-3 form (see below).
+  `United Kingdom`, and must match `UK_POSTCODE_PATTERN` — a **full** postcode
+  (`SW1A 1AA`), inward half included, since the outward code alone can't identify
+  a parliamentary constituency. A missing or repeated inner space is tolerated.
+  Collected on step 1 and the browse signup, stored normalised (uppercased, one
+  inner space) in Airtable's `Zip code` field. Not re-checked on an update; the
+  volunteer step reposts it from state. For a non-UK country the field is
+  ignored. The US volunteer ZIP uses the same `zip_code` field on the step-3
+  form (see below).
 - `intent` must be one of `INTENTS` (`None` | `Keep informed` | `Act now` |
   `Volunteer` | `Lead`). Step 2 submits `None` when no intent is picked; the
   browse signup hardcodes `Act now`; `/subscribe` hardcodes `None`. No form emits

--- a/src/lib/components/onboarding/OnboardingFlow.svelte
+++ b/src/lib/components/onboarding/OnboardingFlow.svelte
@@ -27,6 +27,8 @@
 		COUNTRY_DIAL_CODES,
 		DISCOVERY_SPECIFY_TRIGGERS,
 		LANGUAGES,
+		UK_POSTCODE_PATTERN,
+		isValidUKPostcode,
 		getDiscoveryOptions,
 		getMotivations,
 		getSkills,
@@ -154,8 +156,24 @@
 		email: initialEmail,
 		country: initialCountry,
 		city: initialCity,
+		// UK only: collected on step 1 (and the browse signup) for every "United
+		// Kingdom" signup, posted as `zip_code` — the same field the US volunteer
+		// ZIP uses. Empty and unvalidated for every other country.
+		postcode: '',
 		newsletter: false
 	})
+
+	// Blocks the step-1 / browse submit when a UK signup hasn't given a usable
+	// postcode. The `pattern` + `required` attributes on the input enforce the
+	// same thing natively; this guard also disables the browse button, which is
+	// gated on other checks too.
+	const ukPostcodeValid = $derived(
+		basics.country !== 'United Kingdom' || isValidUKPostcode(basics.postcode)
+	)
+
+	// `pattern` attribute form of UK_POSTCODE_PATTERN: HTML anchors the match
+	// itself, so strip the leading ^ and trailing $.
+	const ukPostcodeInputPattern = UK_POSTCODE_PATTERN.source.replace(/^\^/, '').replace(/\$$/, '')
 
 	// A newsletter signup elsewhere (e.g. the homepage box) can hand off here
 	// via ?subscribe-email=...; that email arrives after mount. Apply it once into
@@ -392,6 +410,11 @@
 	<input type="hidden" name="email" value={basics.email} />
 	<input type="hidden" name="country" value={basics.country} />
 	<input type="hidden" name="city" value={basics.city} />
+	<!-- UK postcode rides the same `zip_code` field as the US volunteer ZIP. Only
+	     posted for a UK signup; the server ignores it for any other country. -->
+	{#if basics.country === 'United Kingdom' && basics.postcode.trim()}
+		<input type="hidden" name="zip_code" value={basics.postcode.trim()} />
+	{/if}
 	{#if basics.newsletter}
 		<input type="hidden" name="newsletter" value="on" />
 	{/if}
@@ -538,6 +561,25 @@
 						bind:value={basics.city}
 					/>
 				</div>
+				{#if basics.country === 'United Kingdom'}
+					<div class="field">
+						<label class="field-label" for="ob-postcode">{msgs.onboarding_field_uk_postcode}</label>
+						<input
+							type="text"
+							id="ob-postcode"
+							required
+							pattern={ukPostcodeInputPattern}
+							placeholder={msgs.onboarding_placeholder_uk_postcode}
+							autocomplete="postal-code"
+							autocapitalize="characters"
+							bind:value={basics.postcode}
+						/>
+						<p class="helper">{msgs.onboarding_helper_uk_postcode}</p>
+					</div>
+				{/if}
+				<!-- Step 1 gates entirely on native validation (required + pattern),
+				     like the name/email/city fields above it — no disabled button, so
+				     the browser can explain an invalid postcode on submit. -->
 				<button type="submit" class="primary">{msgs.onboarding_btn_continue}</button>
 				<div class="browse-option">
 					<button type="button" class="secondary" onclick={startBrowse}>
@@ -777,13 +819,36 @@
 									bind:value={basics.city}
 								/>
 							</div>
+							{#if basics.country === 'United Kingdom'}
+								<div class="field">
+									<label class="field-label" for="loop-postcode"
+										>{msgs.onboarding_field_uk_postcode}</label
+									>
+									<input
+										type="text"
+										id="loop-postcode"
+										name="zip_code"
+										required
+										pattern={ukPostcodeInputPattern}
+										placeholder={msgs.onboarding_placeholder_uk_postcode}
+										autocomplete="postal-code"
+										autocapitalize="characters"
+										bind:value={basics.postcode}
+									/>
+									<p class="helper">{msgs.onboarding_helper_uk_postcode}</p>
+								</div>
+							{/if}
 							{@render gdprConsentField()}
 							{#if onboardingLive && onboardingModeKnown}
 								{#key turnstileNonce}
 									<Turnstile bind:token={turnstileToken} />
 								{/key}
 							{/if}
-							<button type="submit" class="primary" disabled={!gdprConsent || !canSubmit}>
+							<button
+								type="submit"
+								class="primary"
+								disabled={!gdprConsent || !ukPostcodeValid || !canSubmit}
+							>
 								{submitting ? msgs.onboarding_btn_signing_up : msgs.onboarding_btn_sign_me_up}
 							</button>
 						</form>

--- a/src/lib/components/onboarding/OnboardingFlow.svelte
+++ b/src/lib/components/onboarding/OnboardingFlow.svelte
@@ -156,9 +156,10 @@
 		email: initialEmail,
 		country: initialCountry,
 		city: initialCity,
-		// UK only: collected on step 1 (and the browse signup) for every "United
-		// Kingdom" signup, posted as `zip_code` — the same field the US volunteer
-		// ZIP uses. Empty and unvalidated for every other country.
+		// UK only: the full postcode, collected on step 1 (and the browse signup)
+		// for every "United Kingdom" signup and posted as `zip_code` — the same
+		// field the US volunteer ZIP uses. Empty and unvalidated for every other
+		// country.
 		postcode: '',
 		newsletter: false
 	})

--- a/src/lib/components/onboarding/messages.ts
+++ b/src/lib/components/onboarding/messages.ts
@@ -262,9 +262,9 @@ const en: OnboardingMessages = {
 	onboarding_placeholder_zip: 'e.g. 02134',
 	onboarding_helper_zip: 'Your 5-digit zip code is used to find your Local Group.',
 	onboarding_field_uk_postcode: 'Postcode *',
-	onboarding_placeholder_uk_postcode: 'e.g. SW1A',
+	onboarding_placeholder_uk_postcode: 'e.g. SW1A 1AA',
 	onboarding_helper_uk_postcode:
-		"Just the first part is fine. We use it to connect you with your MP's constituency and your nearest local group.",
+		"Your full postcode. We use it to connect you with your MP's constituency and your nearest local group.",
 	onboarding_field_discord: 'Discord username',
 	onboarding_helper_discord:
 		'If you don\'t have a Discord account, we encourage you to <a target="_blank" rel="noopener noreferrer" href="https://discord.com/register">create one here</a>.',
@@ -485,9 +485,9 @@ const de: OnboardingMessages = {
 	onboarding_helper_zip:
 		'Deine 5-stellige Postleitzahl wird verwendet, um deine lokale Gruppe zu finden.',
 	onboarding_field_uk_postcode: 'Postleitzahl (UK) *',
-	onboarding_placeholder_uk_postcode: 'z. B. SW1A',
+	onboarding_placeholder_uk_postcode: 'z. B. SW1A 1AA',
 	onboarding_helper_uk_postcode:
-		'Der erste Teil genügt. Wir nutzen ihn, um dich deinem Wahlkreis und der nächsten lokalen Gruppe zuzuordnen.',
+		'Deine vollständige Postleitzahl. Wir nutzen sie, um dich deinem Wahlkreis und der nächsten lokalen Gruppe zuzuordnen.',
 	onboarding_field_discord: 'Discord-Benutzername',
 	onboarding_helper_discord:
 		'Wenn du noch kein Discord-Konto hast, empfehlen wir dir, <a target="_blank" rel="noopener noreferrer" href="https://discord.com/register">hier eines zu erstellen</a>.',
@@ -713,9 +713,9 @@ const fr: OnboardingMessages = {
 	onboarding_placeholder_zip: 'ex. 75001',
 	onboarding_helper_zip: 'Ton code postal permet de trouver ton groupe local.',
 	onboarding_field_uk_postcode: 'Code postal (UK) *',
-	onboarding_placeholder_uk_postcode: 'ex. SW1A',
+	onboarding_placeholder_uk_postcode: 'ex. SW1A 1AA',
 	onboarding_helper_uk_postcode:
-		'La première partie suffit. Elle nous permet de te rattacher à ta circonscription et au groupe local le plus proche.',
+		'Ton code postal complet. Il nous permet de te rattacher à ta circonscription et au groupe local le plus proche.',
 	onboarding_field_discord: "Nom d'utilisateur Discord",
 	onboarding_helper_discord:
 		'Si tu n\'as pas de compte Discord, nous t\'encourageons à en <a target="_blank" rel="noopener noreferrer" href="https://discord.com/register">créer un ici</a>.',

--- a/src/lib/components/onboarding/messages.ts
+++ b/src/lib/components/onboarding/messages.ts
@@ -261,7 +261,7 @@ const en: OnboardingMessages = {
 	onboarding_field_zip: 'Zip code',
 	onboarding_placeholder_zip: 'e.g. 02134',
 	onboarding_helper_zip: 'Your 5-digit zip code is used to find your Local Group.',
-	onboarding_field_uk_postcode: 'Postcode',
+	onboarding_field_uk_postcode: 'Postcode *',
 	onboarding_placeholder_uk_postcode: 'e.g. SW1A',
 	onboarding_helper_uk_postcode:
 		"Just the first part is fine. We use it to connect you with your MP's constituency and your nearest local group.",
@@ -484,7 +484,7 @@ const de: OnboardingMessages = {
 	onboarding_placeholder_zip: 'z. B. 02134',
 	onboarding_helper_zip:
 		'Deine 5-stellige Postleitzahl wird verwendet, um deine lokale Gruppe zu finden.',
-	onboarding_field_uk_postcode: 'Postleitzahl (UK)',
+	onboarding_field_uk_postcode: 'Postleitzahl (UK) *',
 	onboarding_placeholder_uk_postcode: 'z. B. SW1A',
 	onboarding_helper_uk_postcode:
 		'Der erste Teil genügt. Wir nutzen ihn, um dich deinem Wahlkreis und der nächsten lokalen Gruppe zuzuordnen.',
@@ -712,7 +712,7 @@ const fr: OnboardingMessages = {
 	onboarding_field_zip: 'Code postal',
 	onboarding_placeholder_zip: 'ex. 75001',
 	onboarding_helper_zip: 'Ton code postal permet de trouver ton groupe local.',
-	onboarding_field_uk_postcode: 'Code postal (UK)',
+	onboarding_field_uk_postcode: 'Code postal (UK) *',
 	onboarding_placeholder_uk_postcode: 'ex. SW1A',
 	onboarding_helper_uk_postcode:
 		'La première partie suffit. Elle nous permet de te rattacher à ta circonscription et au groupe local le plus proche.',

--- a/src/lib/components/onboarding/messages.ts
+++ b/src/lib/components/onboarding/messages.ts
@@ -67,6 +67,9 @@ export interface OnboardingMessages {
 	onboarding_field_zip: string
 	onboarding_placeholder_zip: string
 	onboarding_helper_zip: string
+	onboarding_field_uk_postcode: string
+	onboarding_placeholder_uk_postcode: string
+	onboarding_helper_uk_postcode: string
 	onboarding_field_discord: string
 	onboarding_helper_discord: string
 	onboarding_field_phone: string
@@ -258,6 +261,10 @@ const en: OnboardingMessages = {
 	onboarding_field_zip: 'Zip code',
 	onboarding_placeholder_zip: 'e.g. 02134',
 	onboarding_helper_zip: 'Your 5-digit zip code is used to find your Local Group.',
+	onboarding_field_uk_postcode: 'Postcode',
+	onboarding_placeholder_uk_postcode: 'e.g. SW1A',
+	onboarding_helper_uk_postcode:
+		"Just the first part is fine. We use it to connect you with your MP's constituency and your nearest local group.",
 	onboarding_field_discord: 'Discord username',
 	onboarding_helper_discord:
 		'If you don\'t have a Discord account, we encourage you to <a target="_blank" rel="noopener noreferrer" href="https://discord.com/register">create one here</a>.',
@@ -477,6 +484,10 @@ const de: OnboardingMessages = {
 	onboarding_placeholder_zip: 'z. B. 02134',
 	onboarding_helper_zip:
 		'Deine 5-stellige Postleitzahl wird verwendet, um deine lokale Gruppe zu finden.',
+	onboarding_field_uk_postcode: 'Postleitzahl (UK)',
+	onboarding_placeholder_uk_postcode: 'z. B. SW1A',
+	onboarding_helper_uk_postcode:
+		'Der erste Teil genügt. Wir nutzen ihn, um dich deinem Wahlkreis und der nächsten lokalen Gruppe zuzuordnen.',
 	onboarding_field_discord: 'Discord-Benutzername',
 	onboarding_helper_discord:
 		'Wenn du noch kein Discord-Konto hast, empfehlen wir dir, <a target="_blank" rel="noopener noreferrer" href="https://discord.com/register">hier eines zu erstellen</a>.',
@@ -701,6 +712,10 @@ const fr: OnboardingMessages = {
 	onboarding_field_zip: 'Code postal',
 	onboarding_placeholder_zip: 'ex. 75001',
 	onboarding_helper_zip: 'Ton code postal permet de trouver ton groupe local.',
+	onboarding_field_uk_postcode: 'Code postal (UK)',
+	onboarding_placeholder_uk_postcode: 'ex. SW1A',
+	onboarding_helper_uk_postcode:
+		'La première partie suffit. Elle nous permet de te rattacher à ta circonscription et au groupe local le plus proche.',
 	onboarding_field_discord: "Nom d'utilisateur Discord",
 	onboarding_helper_discord:
 		'Si tu n\'as pas de compte Discord, nous t\'encourageons à en <a target="_blank" rel="noopener noreferrer" href="https://discord.com/register">créer un ici</a>.',

--- a/src/lib/components/onboarding/options.test.ts
+++ b/src/lib/components/onboarding/options.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest'
+import { isValidUKPostcode, normaliseUKPostcode } from './options.js'
+
+describe('isValidUKPostcode', () => {
+	it('accepts an outward code on its own', () => {
+		for (const value of ['SW1A', 'M1', 'B33', 'CR2', 'DN55', 'EC1A', 'W1']) {
+			expect(isValidUKPostcode(value)).toBe(true)
+		}
+	})
+
+	it('accepts a full postcode, with or without the inner space', () => {
+		for (const value of ['SW1A 1AA', 'SW1A1AA', 'M1 1AE', 'B33 8TH', 'DN55 1PT', 'ec1a 1bb']) {
+			expect(isValidUKPostcode(value)).toBe(true)
+		}
+	})
+
+	it('ignores surrounding whitespace', () => {
+		expect(isValidUKPostcode('  SW1A 1AA  ')).toBe(true)
+	})
+
+	it('rejects non-UK shapes and junk', () => {
+		for (const value of ['', '12345', 'ZZ', 'SW1A 1A', 'SW1A 1AAA', 'postcode', '1SW 1AA']) {
+			expect(isValidUKPostcode(value)).toBe(false)
+		}
+	})
+})
+
+describe('normaliseUKPostcode', () => {
+	it('uppercases, trims and collapses internal spacing', () => {
+		expect(normaliseUKPostcode('  sw1a   1aa ')).toBe('SW1A 1AA')
+		expect(normaliseUKPostcode('m1')).toBe('M1')
+	})
+})

--- a/src/lib/components/onboarding/options.test.ts
+++ b/src/lib/components/onboarding/options.test.ts
@@ -2,20 +2,28 @@ import { describe, expect, it } from 'vitest'
 import { isValidUKPostcode, normaliseUKPostcode } from './options.js'
 
 describe('isValidUKPostcode', () => {
-	it('accepts an outward code on its own', () => {
-		for (const value of ['SW1A', 'M1', 'B33', 'CR2', 'DN55', 'EC1A', 'W1']) {
-			expect(isValidUKPostcode(value)).toBe(true)
-		}
-	})
-
 	it('accepts a full postcode, with or without the inner space', () => {
-		for (const value of ['SW1A 1AA', 'SW1A1AA', 'M1 1AE', 'B33 8TH', 'DN55 1PT', 'ec1a 1bb']) {
+		for (const value of [
+			'SW1A 1AA',
+			'SW1A1AA',
+			'M1 1AE',
+			'M11AE',
+			'B33 8TH',
+			'DN55 1PT',
+			'ec1a 1bb'
+		]) {
 			expect(isValidUKPostcode(value)).toBe(true)
 		}
 	})
 
 	it('ignores surrounding whitespace', () => {
 		expect(isValidUKPostcode('  SW1A 1AA  ')).toBe(true)
+	})
+
+	it('rejects an outward code on its own — the inward half is required', () => {
+		for (const value of ['SW1A', 'M1', 'B33', 'CR2', 'DN55', 'EC1A']) {
+			expect(isValidUKPostcode(value)).toBe(false)
+		}
 	})
 
 	it('rejects non-UK shapes and junk', () => {
@@ -26,8 +34,13 @@ describe('isValidUKPostcode', () => {
 })
 
 describe('normaliseUKPostcode', () => {
-	it('uppercases, trims and collapses internal spacing', () => {
-		expect(normaliseUKPostcode('  sw1a   1aa ')).toBe('SW1A 1AA')
-		expect(normaliseUKPostcode('m1')).toBe('M1')
+	it('uppercases and puts exactly one space before the inward code', () => {
+		expect(normaliseUKPostcode('  sw1a1aa ')).toBe('SW1A 1AA')
+		expect(normaliseUKPostcode('sw1a   1aa')).toBe('SW1A 1AA')
+		expect(normaliseUKPostcode('M11AE')).toBe('M1 1AE')
+	})
+
+	it('leaves a too-short value compacted for validation to reject', () => {
+		expect(normaliseUKPostcode(' m1 ')).toBe('M1')
 	})
 })

--- a/src/lib/components/onboarding/options.ts
+++ b/src/lib/components/onboarding/options.ts
@@ -220,6 +220,23 @@ export const COUNTRIES = [
 	'Zimbabwe'
 ]
 
+// UK postcode, collected on step 1 for every "United Kingdom" signup and stored
+// in the same Airtable `Zip code` field the US volunteer ZIP uses. People are
+// told the outward code alone (e.g. "SW1A") is enough, so the inward half is
+// optional; the pattern accepts either that or a full postcode ("SW1A 1AA").
+// Case-insensitive, and tolerant of the space between the two halves.
+export const UK_POSTCODE_PATTERN = /^[A-Za-z]{1,2}\d[A-Za-z\d]?(\s*\d[A-Za-z]{2})?$/
+
+export function isValidUKPostcode(value: string): boolean {
+	return UK_POSTCODE_PATTERN.test(value.trim())
+}
+
+// Uppercased, single-spaced. What we send to Airtable so rows are consistent
+// regardless of how the visitor typed it.
+export function normaliseUKPostcode(value: string): string {
+	return value.trim().toUpperCase().replace(/\s+/g, ' ')
+}
+
 // International dialing code per country, keyed by the COUNTRIES names above.
 // Used to prefill the phone field's dial code from the country of residence.
 export const COUNTRY_DIAL_CODES: Record<string, string> = {

--- a/src/lib/components/onboarding/options.ts
+++ b/src/lib/components/onboarding/options.ts
@@ -221,20 +221,25 @@ export const COUNTRIES = [
 ]
 
 // UK postcode, collected on step 1 for every "United Kingdom" signup and stored
-// in the same Airtable `Zip code` field the US volunteer ZIP uses. People are
-// told the outward code alone (e.g. "SW1A") is enough, so the inward half is
-// optional; the pattern accepts either that or a full postcode ("SW1A 1AA").
-// Case-insensitive, and tolerant of the space between the two halves.
-export const UK_POSTCODE_PATTERN = /^[A-Za-z]{1,2}\d[A-Za-z\d]?(\s*\d[A-Za-z]{2})?$/
+// in the same Airtable `Zip code` field the US volunteer ZIP uses. The full
+// postcode is required — the outward code alone ("SW1A") is not enough to
+// identify a parliamentary constituency, which is what downstream routing needs.
+// So the inward half (digit + two letters) is mandatory. Case-insensitive, and
+// tolerant of a missing or repeated space between the two halves.
+export const UK_POSTCODE_PATTERN = /^[A-Za-z]{1,2}\d[A-Za-z\d]?\s*\d[A-Za-z]{2}$/
 
 export function isValidUKPostcode(value: string): boolean {
 	return UK_POSTCODE_PATTERN.test(value.trim())
 }
 
-// Uppercased, single-spaced. What we send to Airtable so rows are consistent
-// regardless of how the visitor typed it.
+// Uppercased, with exactly one space before the inward code ("SW1A 1AA"),
+// however the visitor typed it. What we send to Airtable so rows are consistent.
+// A value too short to split is returned compacted and left for validation to
+// reject.
 export function normaliseUKPostcode(value: string): string {
-	return value.trim().toUpperCase().replace(/\s+/g, ' ')
+	const compact = value.trim().toUpperCase().replace(/\s+/g, '')
+	if (compact.length < 5) return compact
+	return `${compact.slice(0, -3)} ${compact.slice(-3)}`
 }
 
 // International dialing code per country, keyed by the COUNTRIES names above.

--- a/src/routes/embed/onboarding-form/+page.server.ts
+++ b/src/routes/embed/onboarding-form/+page.server.ts
@@ -185,7 +185,7 @@ export const actions: Actions = {
 		const ukPostcode = isUK ? normaliseUKPostcode(getString(data, 'zip_code')) : ''
 		if (isUK && !existingRecordId && !isValidUKPostcode(ukPostcode)) {
 			return fail(400, {
-				message: 'Please enter a UK postcode (the first part, e.g. SW1A, is enough).'
+				message: 'Please enter your full UK postcode, e.g. SW1A 1AA.'
 			})
 		}
 		if (!isIntent(intent)) {

--- a/src/routes/embed/onboarding-form/+page.server.ts
+++ b/src/routes/embed/onboarding-form/+page.server.ts
@@ -29,6 +29,8 @@ import {
 	SUBSCRIBE_SIGNUP_SOURCE,
 	SKILLS,
 	WEEKLY_HOURS,
+	isValidUKPostcode,
+	normaliseUKPostcode,
 	type Intent
 } from '$lib/components/onboarding/options'
 
@@ -175,6 +177,17 @@ export const actions: Actions = {
 		if (country && !COUNTRIES.includes(country)) {
 			return fail(400, { message: 'Please select a country from the list.' })
 		}
+		// UK postcode: collected on step 1 (and the browse signup) for every UK
+		// signup, posted through the same `zip_code` field the US volunteer ZIP
+		// uses. Required on a create; an update (the volunteer step) reposts it
+		// from state but is not re-checked, matching how the other basics behave.
+		const isUK = country === 'United Kingdom'
+		const ukPostcode = isUK ? normaliseUKPostcode(getString(data, 'zip_code')) : ''
+		if (isUK && !existingRecordId && !isValidUKPostcode(ukPostcode)) {
+			return fail(400, {
+				message: 'Please enter a UK postcode (the first part, e.g. SW1A, is enough).'
+			})
+		}
 		if (!isIntent(intent)) {
 			return fail(400, { message: 'Please choose what brings you here.' })
 		}
@@ -232,6 +245,10 @@ export const actions: Actions = {
 		if (!existingRecordId || fullName) fields['Full name'] = fullName
 		if (!existingRecordId || country) fields.Country = country
 		if (!existingRecordId || city) fields.City = city
+		// UK postcode shares Airtable's `Zip code` field with the US volunteer ZIP
+		// (written further down, in the volunteer block). Only ever set when
+		// non-empty, so a partial repost can't blank it.
+		if (isUK && ukPostcode) fields['Zip code'] = ukPostcode
 		if (chapterShare !== undefined) {
 			fields['GDPR chapter share permission'] = chapterShare
 		}


### PR DESCRIPTION
## What

UK signups now enter their **full** postcode (e.g. `SW1A 1AA`) on the basic-info step and the browse "keep me informed" signup. Shown only when country is United Kingdom, required on a create, validated client-side (native `required` + `pattern`) and in the submit action.

## Details

- **Full postcode required.** The outward code alone (`SW1A`) can't identify a parliamentary constituency, which is what downstream routing needs, so `UK_POSTCODE_PATTERN` requires the inward half (digit + two letters). A missing or repeated inner space is tolerated.
- **Storage.** Written to Airtable's `Zip code` field, normalised to uppercase with one inner space (`SW1A 1AA`). Shares that field with the US volunteer ZIP — the field's own description already documents both uses (single line text, kept as text to preserve leading 0s).
- **Label** carries a trailing `*` like the other required step-1 fields; copy in en/de/fr.
- Not re-checked on updates (the volunteer step reposts it from state); ignored for non-UK countries.
- `docs/join-form-flow.md` updated (step machine, Airtable field list, validation rules).
- New unit tests for `isValidUKPostcode` / `normaliseUKPostcode`.

### Accepted / rejected

| Accepted | Rejected |
|---|---|
| `SW1A 1AA`, `SW1A1AA`, `M1 1AE`, `B33 8TH`, `ec1a 1bb` | `SW1A`, `M1` (outward only), `SW1A 1A`, `12345`, empty |

## City field

Considered dropping `City` for UK now that postcode is precise. Decision: **keep it as-is** — the field is global (non-UK still needs it), it's the only human-readable town signal on a UK row until a postcode→place lookup exists, and Airtable automations may key on it (they live in Airtable, not this repo, so unverified). Revisit when the constituency lookup lands and can backfill City.

## Test plan

- [x] `pnpm check` — 0 errors
- [x] `pnpm lint` — clean (2 pre-existing warnings, unrelated)
- [x] `pnpm test` — 56 passing
- [ ] Manual: `/join` with country = United Kingdom, confirm postcode field appears, `*` shown, full postcode enforced, value lands in Airtable `Zip code`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WT1uq8GKFmzkJQdiMttSJt