### PR TITLE
Sync national chapter Luma calendar IDs and drive /api/calendar from synced data

### DIFF
--- a/scripts/sync-national-chapters.ts
+++ b/scripts/sync-national-chapters.ts
@@ -1,5 +1,5 @@
 /**
- * Syncs src/routes/communities/national-chapters.json with the national groups
+ * Syncs src/lib/data/national-chapters.json with the national groups
  * served by https://pauseai.info/api/national-groups (backed by the Airtable
  * "National groups" table).
  *
@@ -9,6 +9,12 @@
  *   neither, so they are never regenerated.
  * - Chapters whose link changed are updated. Changes are non-invasive: only
  *   outdated values are touched, never the ordering of existing entries.
+ * - When a group has a Luma page (the `luma` field in Airtable), the page is
+ *   fetched to resolve its calendar API ID (cal-…), stored as lumaCalendarId —
+ *   the ID that /api/calendar needs to pull the chapter's events via Luma's
+ *   get-items API. The Luma URL itself is not stored. A failed resolution
+ *   keeps the previously stored ID, so a transient Luma hiccup can never wipe
+ *   known-good data.
  * - Countries that are new to the JSON are appended, geocoded (Nominatim,
  *   one request per second, honoring their fair-use policy) to get map
  *   coordinates.
@@ -30,10 +36,10 @@ import fs from 'node:fs'
 import { fileURLToPath } from 'node:url'
 import minimist from 'minimist'
 import type { NationalGroup } from '../src/lib/types.js'
-import nationalChaptersJson from '../src/routes/communities/national-chapters.json'
+import nationalChaptersJson from '../src/lib/data/national-chapters.json'
 
 const TARGET_FILE = fileURLToPath(
-	new URL('../src/routes/communities/national-chapters.json', import.meta.url)
+	new URL('../src/lib/data/national-chapters.json', import.meta.url)
 )
 
 /**
@@ -61,7 +67,14 @@ const NOMINATIM_USER_AGENT =
 const NOMINATIM_MIN_INTERVAL_MS = 1000
 
 // Inferred from the JSON so the type can't drift from the data it describes.
-type Chapter = (typeof nationalChaptersJson.communities)[number]
+// lumaCalendarId is omitted from the inferred union before being re-added as
+// optional: chapters only carry it when the Airtable group has a Luma page,
+// and intersecting the union directly would freeze it to `undefined` on the
+// members that lack the key.
+type InferredChapter = (typeof nationalChaptersJson.communities)[number]
+type Chapter = Omit<InferredChapter, 'lumaCalendarId'> & {
+	lumaCalendarId?: string
+}
 
 const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms))
 
@@ -131,6 +144,62 @@ function primaryLink(group: NationalGroup): string {
 	return group.email ? `mailto:${group.email}` : ``
 }
 
+/**
+ * The Luma page URL stored on the group in Airtable, normalized, but only if
+ * it points at a Luma page (lu.ma / luma.com). Anything else — event-specific
+ * URLs, typos, other platforms pasted into the wrong column — is dropped
+ * rather than resolved. The scheme is optional in Airtable (e.g.
+ * "luma.com/pauseai-ch" was observed) and added if missing.
+ */
+function lumaCalendarLink(group: NationalGroup): string | undefined {
+	const link = group.lumaLink?.trim()
+	if (!link) return undefined
+	// Scheme is optional in Airtable ("luma.com/pauseai-ch" was observed);
+	// default to https so the URL check below can match.
+	const normalized = /^https?:\/\//.test(link)
+		? link.replace(/^http:\/\//, 'https://')
+		: `https://${link}`
+	return /^https:\/\/(lu\.ma|luma\.com)\//.test(normalized) ? normalized : undefined
+}
+
+const LUMA_PAGE_DELAY_MS = 250
+// Per-run cache so the same Luma page is never fetched twice.
+const calendarIdCache = new Map<string, string | null>()
+
+/**
+ * Resolves a Luma page URL (https://luma.com/pauseaimtl) to the calendar API
+ * ID (cal-…) that /api/calendar needs for Luma's get-items endpoint. Luma has
+ * no documented way to look the ID up from the vanity URL, but it is embedded
+ * in the page's HTML as `"api_id":"cal-…"` / `"calendar_api_id":"cal-…"`.
+ * Anchoring on those JSON keys avoids false positives like the CSS class
+ * `cal-padding`. On failure, falls back to the ID already stored in the JSON
+ * (if any) instead of failing the whole sync.
+ */
+async function resolveCalendarId(lumaLink: string, chapter: Chapter): Promise<string | undefined> {
+	const existing = chapter.lumaCalendarId
+	if (calendarIdCache.has(lumaLink)) return calendarIdCache.get(lumaLink) ?? existing
+	await sleep(LUMA_PAGE_DELAY_MS)
+	try {
+		const response = await fetch(lumaLink, {
+			headers: { 'User-Agent': NOMINATIM_USER_AGENT }
+		})
+		if (!response.ok) throw new Error(`HTTP ${response.status}`)
+		const html = await response.text()
+		const id =
+			html.match(/"api_id":"(cal-[A-Za-z0-9]+)"/)?.[1] ??
+			html.match(/"calendar_api_id":"(cal-[A-Za-z0-9]+)"/)?.[1]
+		if (!id) throw new Error('no calendar ID found in page HTML')
+		calendarIdCache.set(lumaLink, id)
+		return id
+	} catch (error) {
+		console.warn(
+			`  ⚠ Could not resolve ${lumaLink} to a calendar ID: ${error instanceof Error ? error.message : String(error)}`
+		)
+		calendarIdCache.set(lumaLink, null)
+		return existing
+	}
+}
+
 async function fetchNationalGroups(): Promise<NationalGroup[]> {
 	const response = await fetch('https://pauseai.info/api/national-groups')
 	if (!response.ok) {
@@ -154,7 +223,9 @@ const allow = new Set<string>(
 )
 
 const current = fs.readFileSync(TARGET_FILE, 'utf8')
-const { communities: existing } = nationalChaptersJson
+// Cast needed: the JSON import's inferred type predates the optional
+// lumaLink/lumaCalendarId keys the sync script may add.
+const existing = nationalChaptersJson.communities as Chapter[]
 const groups = await fetchNationalGroups()
 const groupName = (group: NationalGroup): string =>
 	NAME_OVERRIDES[group.name.trim()] ?? group.name.trim()
@@ -163,7 +234,8 @@ const chapters: Chapter[] = []
 const skipped: string[] = []
 
 // Existing chapters keep their position in the file; only update their link
-// when it changed, or drop them when the API no longer lists them.
+// or lumaCalendarId when it changed, or drop them when the API no longer
+// lists them.
 for (const chapter of existing) {
 	const group = groups.find((g) => groupName(g) === chapter.name)
 	if (!group) {
@@ -171,9 +243,20 @@ for (const chapter of existing) {
 		continue
 	}
 	const link = primaryLink(group)
-	if (link !== chapter.link) {
-		console.log(`  – Updating link for ${chapter.name}: ${chapter.link} → ${link}`)
-		chapters.push({ ...chapter, link })
+	const lumaLink = lumaCalendarLink(group)
+	const lumaCalendarId = lumaLink ? await resolveCalendarId(lumaLink, chapter) : undefined
+	const lumaChanged = lumaCalendarId !== chapter.lumaCalendarId
+	if (link !== chapter.link || lumaChanged) {
+		console.log(
+			`  – Updating ${chapter.name}: link ${chapter.link} → ${link}` +
+				(lumaChanged
+					? `, calendar ID ${chapter.lumaCalendarId ?? '—'} → ${lumaCalendarId ?? '—'}`
+					: '')
+		)
+		const nextChapter: Chapter = { ...chapter, link }
+		if (lumaCalendarId) nextChapter.lumaCalendarId = lumaCalendarId
+		else delete nextChapter.lumaCalendarId // group lost its Luma page or ID
+		chapters.push(nextChapter)
 	} else {
 		chapters.push(chapter)
 	}
@@ -194,6 +277,10 @@ for (const group of groups) {
 	}
 
 	const link = primaryLink(group)
+	const lumaLink = lumaCalendarLink(group)
+	const lumaCalendarId = lumaLink
+		? await resolveCalendarId(lumaLink, { name } as Chapter)
+		: undefined
 	const geocoded = await geocodeCountry(group.name.trim())
 	if (!geocoded) {
 		skipped.push(name)
@@ -208,7 +295,14 @@ for (const group of groups) {
 	console.log(
 		`  + Adding new country: ${name}${geocoded.localName ? ` (${geocoded.localName})` : ''}`
 	)
-	chapters.push({ name, lat: geocoded.coords[0], lon: geocoded.coords[1], link, ...local })
+	chapters.push({
+		name,
+		lat: geocoded.coords[0],
+		lon: geocoded.coords[1],
+		link,
+		...(lumaCalendarId ? { lumaCalendarId } : {}),
+		...local
+	})
 }
 
 if (skipped.length > 0) {

--- a/src/lib/data/national-chapters.json
+++ b/src/lib/data/national-chapters.json
@@ -30,7 +30,8 @@
 			"name": "Canada",
 			"lat": 56,
 			"lon": -105,
-			"link": "https://pauseai.ca/en/"
+			"link": "https://pauseai.ca/en/",
+			"lumaCalendarId": "cal-BR40B7NsaOMrV40"
 		},
 		{
 			"name": "Romania",
@@ -56,7 +57,8 @@
 			"name": "Australia",
 			"lat": -25,
 			"lon": 134.5,
-			"link": "https://pauseai.info/australia"
+			"link": "https://pauseai.info/australia",
+			"lumaCalendarId": "cal-gnpo62PdSdau7KQ"
 		},
 		{
 			"name": "Germany",
@@ -121,7 +123,8 @@
 			"name": "Switzerland",
 			"lat": 46.7985624,
 			"lon": 8.2319736,
-			"link": "https://chat.whatsapp.com/BKt0uKPVLDKFLomW4CrTVH"
+			"link": "https://chat.whatsapp.com/BKt0uKPVLDKFLomW4CrTVH",
+			"lumaCalendarId": "cal-lMws4StD94Vb02J"
 		}
 	]
 }

--- a/src/routes/api/calendar/+server.ts
+++ b/src/routes/api/calendar/+server.ts
@@ -2,6 +2,7 @@ import * as Calendar from '$lib/clients/luma/calendar'
 import { generateCacheControlRecord } from '$lib/utils.js'
 import { json } from '@sveltejs/kit'
 import type { RequestHandler } from './$types'
+import nationalChaptersJson from '$lib/data/national-chapters.json'
 
 export type CalendarResponse = {
 	entries: {
@@ -19,12 +20,15 @@ export type Event = {
 
 export const prerender = false
 
+// The global calendar stays hardcoded; national chapter calendars are synced
+// from Airtable into national-chapters.json by scripts/sync-national-chapters.ts
+// (lumaCalendarId, resolved from each chapter's Luma page at sync time).
+const GLOBAL_CALENDAR_ID = 'cal-E1qhLPs5IvlQr8S'
 const CALENDAR_IDS = [
-	'cal-E1qhLPs5IvlQr8S', // global
-	'cal-Z327EhtiFdHuVie', // UK
-	'cal-gnpo62PdSdau7KQ', // AU
-	'cal-tsYv79s4aTQC16Q', // CA
-	'cal-B1ELepcLXLcAqMf' // DE
+	GLOBAL_CALENDAR_ID,
+	...nationalChaptersJson.communities
+		.map((c) => c.lumaCalendarId)
+		.filter((id): id is string => id != null)
 ]
 
 export const GET: RequestHandler = async ({ url, setHeaders }) => {

--- a/src/routes/communities/communities.ts
+++ b/src/routes/communities/communities.ts
@@ -1,7 +1,7 @@
 import type { StrictPost } from '$lib/types'
 import adjacentCommunitiesJson from './adjacent-communities.json'
 import pauseAICommunitiesJson from './pauseai-communities.json'
-import nationalChaptersJson from './national-chapters.json'
+import nationalChaptersJson from '$lib/data/national-chapters.json'
 
 export type CommunitiesConfiguration = {
 	communities: RawCommunity[]


### PR DESCRIPTION
## What

Moves the national chapter Luma calendar IDs from a hardcoded list in `/api/calendar` to data synced from Airtable.

- **`scripts/sync-national-chapters.ts`**: when a group in Airtable has a Luma page (`luma` field), the script now fetches that page and resolves its calendar API ID (`cal-…`), storing it as `lumaCalendarId` in `national-chapters.json`. The Luma URL itself is **not** stored — only the ID `/api/calendar` needs. Scheme-less Airtable values (e.g. `luma.com/pauseai-ch`) are normalized to `https://`. Failed resolutions keep the previously stored ID, so a transient Luma hiccup can never wipe known-good data.
- **`/api/calendar`**: the calendar ID list is now built from the synced JSON (`lumaCalendarId` values) plus the hardcoded global calendar, instead of a hardcoded per-country list.
- **Moved** `national-chapters.json` from `src/routes/communities/` to `src/lib/data/` so the communities page and the calendar API both import from a shared, non-route location.

## ⚠️ Do not merge yet — Airtable updates pending

The refactor changes which calendars `/api/calendar` serves. Current state vs. the old hardcoded list:

- ✅ **Australia** — unchanged (`cal-gnpo62PdSdau7KQ`)
- 🆕 **Switzerland** — newly gained (`cal-lMws4StD94Vb02J`)
- ⚠️ **Canada** — changed: now the **Montreal** calendar (`cal-BR40B7NsaOMrV40`) because Airtable's `luma` field points there; the national "PauseAI Canada" calendar (`cal-tsYv79s4aTQC16Q`, no vanity slug) is dropped. Decide which is intended before merging.
- ❌ **United Kingdom** (`cal-Z327EhtiFdHuVie`) and **Germany** (`cal-B1ELepcLXLcAqMf`) — **dropped**, because those chapters have no `luma` value in Airtable yet.

**Required Airtable updates before merging:**
1. UK: add `https://lu.ma/pauseai.uk` to the chapter's `luma` field
2. DE: add `https://lu.ma/pauseai_de`
3. Canada: decide Montreal vs. national calendar and set the field accordingly (national one has no vanity slug — consider claiming one in Luma, e.g. `lu.ma/PauseAICanada`)

After the Airtable edits, run `pnpm sync:national-chapters` and commit the refreshed JSON — then merge.

## Verification

- `pnpm check` — 0 errors
- ESLint + Prettier clean
- `pnpm sync:national-chapters -- --check` — JSON in sync with pauseai.info