### PR TITLE
PauseAI Sverige: styled layout, and their own line about PauseAI Global

### DIFF
--- a/src/lib/server/onboardingEmail/chapterOverrides.ts
+++ b/src/lib/server/onboardingEmail/chapterOverrides.ts
@@ -1,5 +1,5 @@
 import type { EmailBlock, EmailContent } from './blocks.js'
-import { GLOBAL_DISCORD_URL, GLOBAL_SOCIALS, VIDEO_URL } from './brand.js'
+import { GLOBAL_DISCORD_URL, GLOBAL_SOCIALS, VIDEO_URL, WELCOME_CALLS_URL } from './brand.js'
 import type {
 	ChapterBlockData,
 	ChapterLink,
@@ -297,11 +297,18 @@ const swedenContent: ChapterContent = (firstName, chapter) => {
 		type: 'paragraph',
 		text: `Skriv gärna på [vår namninsamling](${SWEDEN_PETITION}) och kika på [vår hemsida](${SWEDEN_ACTION_PAGE}) för att få fler tips på vad du kan göra.`
 	})
+	// A chapter's own email replaces the shared next steps, so its readers hear about PauseAI
+	// Global only if the chapter says so. Theirs to keep or drop, like the rest of this copy.
+	body.push({
+		type: 'paragraph',
+		text: `Du är också välkommen till PauseAI Globals [välkomstmöten](${WELCOME_CALLS_URL}) för nya volontärer och till deras [Discord-server](${GLOBAL_DISCORD_URL}). Båda är på engelska.`
+	})
 
 	return {
 		subject: `Välkommen till PauseAI Sverige, ${firstName}!`,
-		htmlStyle: 'plain',
-		greeting: [{ type: 'paragraph', text: `Hej ${firstName} och välkommen till PauseAI Sverige!` }],
+		greeting: [
+			{ type: 'heading', level: 1, text: `Hej ${firstName} och välkommen till PauseAI Sverige!` }
+		],
 		body,
 		signoff: [{ type: 'signoff', lines: ['Mvh', 'Carl, PauseAI Sverige'] }]
 	}

--- a/src/lib/server/onboardingEmail/fixed.ts
+++ b/src/lib/server/onboardingEmail/fixed.ts
@@ -58,9 +58,9 @@ const sv: FixedCopy = {
 	confirm: (link) =>
 		`Bekräfta din e-postadress genom att klicka på [den här länken](${link}). Om du inte har anmält dig kan du bortse från det här meddelandet.`,
 	newsletter: () =>
-		'Om du har valt att prenumerera håller vi dig uppdaterad om nyheter, kampanjer och sätt att engagera dig. Oavsett vilket kan vi ibland skicka dig en kritisk varning.',
+		'Om du har valt att prenumerera håller vi dig uppdaterad om nyheter, kampanjer och sätt att engagera dig. Även om du inte prenumererar kan vi ibland skicka ett viktigt och brådskande meddelande.',
 	newsletterInOwnWords:
-		'Om du har valt att prenumerera håller vi dig uppdaterad. Oavsett vilket kan vi ibland skicka dig en kritisk varning.'
+		'Om du har valt att prenumerera håller vi dig uppdaterad. Även om du inte prenumererar kan vi ibland skicka ett viktigt och brådskande meddelande.'
 }
 
 export const FIXED_COPY: Record<OnboardingEmailLanguage, FixedCopy> = { en, es, sv }


### PR DESCRIPTION
PauseAI Sverige asked for the styled layout rather than the plain note, so their greeting becomes the email's title and the rest follows the shared design.

Their email replaces the shared next steps, so its readers heard nothing about PauseAI Global. It now says so in its own copy, in Swedish, noting that the welcome meetings and the Discord are in English. Theirs to keep or drop, like the rest of it.

The Swedish alert line also changes: a native reader heard "kritisk varning" as a technical system alarm rather than the occasional urgent message it describes.

Read it at [/onboarding-email-preview?country=Sweden](https://pauseai.netlify.app/onboarding-email-preview?country=Sweden&intent=Volunteer) on the deploy preview. Going to the chapter for review either way.
