### PR TITLE
fix: pass chapter sync PR body via env var instead of file path

### DIFF
--- a/.github/workflows/sync-national-chapters.yml
+++ b/.github/workflows/sync-national-chapters.yml
@@ -31,16 +31,26 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Run sync
-        # The summary file is the PR body for create-pull-request; it lives in
-        # the runner temp dir so it is never committed.
-        run: pnpm sync:national-chapters -- --summary "$RUNNER_TEMP/national-chapters-pr-body.md"
+        # The summary file is created and consumed within this step; its
+        # content is handed to create-pull-request via a job-level env var
+        # (multiline-safe via the delimiter syntax), so no file has to
+        # survive between steps.
+        run: |
+          summary="$RUNNER_TEMP/national-chapters-pr-body.md"
+          pnpm exec tsx scripts/sync-national-chapters.ts --summary "$summary"
+          test -f "$summary" || { echo "::error::sync script did not write $summary"; exit 1; }
+          {
+            echo "pr_body<<PAUSEAI_PR_BODY_EOF"
+            cat "$summary"
+            echo "PAUSEAI_PR_BODY_EOF"
+          } >> "$GITHUB_ENV"
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v8
         with:
           commit-message: 'Sync national chapters with pauseai.info'
           title: 'Sync national chapters with pauseai.info'
-          body-path: ${{ runner.temp }}/national-chapters-pr-body.md
+          body: ${{ env.pr_body }}
           branch: sync-national-chapters
           base: main
           delete-branch: true


### PR DESCRIPTION
## Summary

Fixes the `Sync national chapters` workflow failure in run [#34754012412](https://github.com/PauseAI/pauseai-website/actions/runs/34754012412), where the "Create Pull Request" step failed with:

> `Error: File '/home/runner/work/_temp/national-chapters-pr-body.md' does not exist.`

even though the "Run sync" step had succeeded.

## What changed

The workflow no longer passes the PR body between steps as a file path. Instead:

- The summary file is created and consumed **within the same step** — no file has to survive between steps at all.
- Its content is handed to `peter-evans/create-pull-request` via a **job-level env var** using the `GITHUB_ENV` multiline delimiter syntax (`pr_body<<PAUSEAI_PR_BODY_EOF`), with `body: ${{ env.pr_body }}`.
- The delimiter (`PAUSEAI_PR_BODY_EOF`) cannot appear in the generated body.
- The sync step now fails loudly with a clear `::error::` annotation if the summary file was not written, instead of failing later in `create-pull-request` with a confusing message.
- CI invokes the script directly via `pnpm exec tsx scripts/sync-national-chapters.ts --summary "$summary"`, ruling out pnpm's `run ... --` argument forwarding as a possible cause of the original failure.
- `add-paths` is no longer needed since no file is written to the workspace.

Follow-up to #1107 (the body-generation feature itself is unchanged — the script still produces the change-focused summary table with chapter links and Luma calendar links).